### PR TITLE
add: Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use Ubuntu 23.10 as the base image
+FROM ubuntu:23.10
+
+# Update and upgrade the system
+RUN apt-get update && \
+    apt-get upgrade -y
+
+# Install necessary packages
+RUN apt-get install -y \
+    python3-pyelftools \
+    python3-requests \
+    git \
+    cmake \
+    ninja-build \
+    build-essential \
+    pkg-config \
+    libicu-dev \
+    libcapstone-dev
+
+# Clone the specified repository
+RUN git clone https://github.com/worawit/blutter.git
+
+# Set the working directory to the cloned repository
+WORKDIR /blutter
+
+# Entry point for running the specific command
+ENTRYPOINT ["python3", "blutter.py"]
+
+# Default command arguments (can be overridden when running the container)
+CMD ["/app/arm64-v8a", "/app/blutter_output"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ python scripts\init_env_win.py
 brew install llvm@16 cmake ninja pkg-config icu4c capstone
 pip3 install pyelftools requests
 ```
+### Docker
+- Install Docker
+- Build Docker image from Dockerfile
+```
+sudo docker build -t blutter .
+```
 
 ## Usage
 Extract "lib" directory from apk file
@@ -44,6 +50,16 @@ python3 blutter.py path/to/app/lib/arm64-v8a out_dir
 The blutter.py will automatically detect the Dart version from the flutter engine and call executable of blutter to get the information from libapp.so.
 
 If the blutter executable for required Dart version does not exists, the script will automatically checkout Dart source code and compiling it.
+
+### Docker
+`cd` inside `lib` directory
+
+Run (`sudo` required to share and write to volumes)
+```
+sudo docker run -it -v "$(pwd):/app" blutter
+```
+The output will be in `lib/blutter_output` directory.
+
 
 ## Update
 You can use ```git pull``` to update and run blutter.py with ```--rebuild``` option to force rebuild the executable


### PR DESCRIPTION
Docker support allows user to install and use blutter without dependency or OS issues.
- Dockerfile creates the image with all the necessary dependencies. It is necessary to share a volume in order to write the resulting directory in the host machine. I also added default command arguments
- README updated with installation instructions.