### PR TITLE
Add docker support for blutter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:unstable-slim
+RUN apt update && apt install -y python3-pyelftools python3-requests git cmake ninja-build \
+    build-essential pkg-config libicu-dev libcapstone-dev
+COPY . /blutter
+VOLUME [ "/data/lib", "/data/output" ]
+WORKDIR /blutter
+CMD [ "python3", "blutter.py",  "/data/lib", "/data/output"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # B(l)utter
+
 Flutter Mobile Application Reverse Engineering Tool by Compiling Dart AOT Runtime
 
 Currently the application supports only Android libapp.so (arm64 only).
@@ -6,59 +7,72 @@ Also the application is currently work only against recent Dart versions.
 
 For high priority missing features, see [TODO](#todo)
 
-
 ## Environment Setup
+
 This application uses C++20 Formatting library. It requires very recent C++ compiler such as g++>=13, Clang>=16.
 
 I recommend using Linux OS (only tested on Deiban sid/trixie) because it is easy to setup.
 
 ### Debian Unstable (gcc 13)
+
 - Install build tools and depenencies
+
 ```
 apt install python3-pyelftools python3-requests git cmake ninja-build \
     build-essential pkg-config libicu-dev libcapstone-dev
 ```
 
 ### Windows
+
 - Install git and python 3
 - Install latest Visual Studio with "Desktop development with C++" and "C++ CMake tools"
 - Install required libraries (libcapstone and libicu4c)
+
 ```
 python scripts\init_env_win.py
 ```
+
 - Start "x64 Native Tools Command Prompt"
 
 ### macOS Ventura and Sonoma (clang 16)
+
 - Install XCode
 - Install clang 16 and required tools
+
 ```
 brew install llvm@16 cmake ninja pkg-config icu4c capstone
 pip3 install pyelftools requests
 ```
 
 ## Usage
+
 Extract "lib" directory from apk file
+
 ```
 python3 blutter.py path/to/app/lib/arm64-v8a out_dir
 ```
+
 The blutter.py will automatically detect the Dart version from the flutter engine and call executable of blutter to get the information from libapp.so.
 
 If the blutter executable for required Dart version does not exists, the script will automatically checkout Dart source code and compiling it.
 
 ## Update
+
 You can use ```git pull``` to update and run blutter.py with ```--rebuild``` option to force rebuild the executable
+
 ```
 python3 blutter.py path/to/app/lib/arm64-v8a out_dir --rebuild
 ```
 
 ## Output files
+
 - **asm/\*** libapp assemblies with symbols
 - **blutter_frida.js** the frida script template for the target application
 - **objs.txt** complete (nested) dump of Object from Object Pool
 - **pp.txt** all Dart objects in Object Pool
 
-
 ## Directories
+
 - **bin** contains blutter executables for each Dart version in "blutter_dartvm\<ver\>\_\<os\>\_\<arch\>" format
 - **blutter** contains source code. need building against Dart VM library
 - **build** contains building projects which can be deleted after finishing the build process
@@ -67,14 +81,16 @@ python3 blutter.py path/to/app/lib/arm64-v8a out_dir --rebuild
 - **packages** contains the static libraries of Dart Runtime
 - **scripts** contains python scripts for getting/building Dart
 
-
 ## Generating Visual Studio Solution for Development
+
 I use Visual Studio to delevlop Blutter on Windows. ```--vs-sln``` options can be used to generate a Visual Studio solution.
+
 ```
 python blutter.py path\to\lib\arm64-v8a build\vs --vs-sln
 ```
 
 ## TODO
+
 - More code analysis
   - Function arguments and return type
   - Some psuedo code for code pattern

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ You can use ```git pull``` to update and run blutter.py with ```--rebuild``` opt
 python3 blutter.py path/to/app/lib/arm64-v8a out_dir --rebuild
 ```
 
+## Usage with docker
+
+You can use docker to run blutter without setting up the environment.
+
+```
+docker build -t blutter .
+```
+
+then,you can use it with following command
+
+```
+docker run --rm blutter -v /path/to/app/lib/arm64-v8a:/data/lib -v /path/to/out_dir:/data/output
+```
+
+blutter also have an unofficial docker image on dockerhub. you can use it with following command.Note that the image is not updated frequently.
+
+```
+docker run --rm yixinbc/blutter -v /path/to/app/lib/arm64-v8a:/data/lib -v /path/to/out_dir:/data/output
+```
+
 ## Output files
 
 - **asm/\*** libapp assemblies with symbols


### PR DESCRIPTION
I spent an afternoon trying to run Blutter on Windows.But I failed.
Then I thought I can create a Docker image to simplify(?) my usage process.
As an alternative to running directly on the operating system, docker provides some advantages,such as avoiding many dependency or OS issues.