### PR TITLE
Check blutter subprocess return status

### DIFF
--- a/blutter.py
+++ b/blutter.py
@@ -157,7 +157,7 @@ def main(indir: str, outdir: str, rebuild_blutter: bool, create_vs_sln: bool, no
             assert os.path.isfile(blutter_file), "Build complete but cannot find Blutter binary: " + blutter_file
 
         # execute blutter    
-        subprocess.run([blutter_file, '-i', libapp_file, '-o', outdir])
+        subprocess.run([blutter_file, '-i', libapp_file, '-o', outdir], check=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is related to issue #83

It doesn't solve the issue, but it makes the failure visible.

(In my case, I get a backtrace and `subprocess.CalledProcessError: Command ... died with <Signals.SIGSEGV: 11>.`)