### PR TITLE
fix: resolve SDK build errors for Dart 3.5.0 changes

### DIFF
--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -96,6 +96,14 @@ void DartDumper::Dump4Ida(std::filesystem::path outDir)
 			for (auto dartFn : cls->Functions()) {
 				const auto ep = dartFn->Address();
 				auto name = getFunctionName4Ida(*dartFn, cls_prefix);
+				std::replace(name.begin(), name.end(), '<', '@');
+				std::replace(name.begin(), name.end(), '>', '@');
+				std::replace(name.begin(), name.end(), ',', '&');
+				std::replace(name.begin(), name.end(), ' ', '_');
+				std::replace(name.begin(), name.end(), '{', '(');
+				std::replace(name.begin(), name.end(), '}', ')');
+				std::replace(name.begin(), name.end(), '|', '.');
+				std::replace(name.begin(), name.end(), '#', '$');
 				of << std::format("ida_funcs.add_func({:#x}, {:#x})\n", ep, ep + dartFn->Size());
 				of << std::format("idaapi.set_name({:#x}, \"{}_{}::{}_{:x}\")\n", ep, lib_prefix, cls_prefix, name.c_str(), ep);
 				if (dartFn->HasMorphicCode()) {
@@ -114,6 +122,10 @@ void DartDumper::Dump4Ida(std::filesystem::path outDir)
 		std::replace(name.begin(), name.end(), '>', '@');
 		std::replace(name.begin(), name.end(), ',', '&');
 		std::replace(name.begin(), name.end(), ' ', '_');
+		std::replace(name.begin(), name.end(), '{', '(');
+		std::replace(name.begin(), name.end(), '}', ')');
+		std::replace(name.begin(), name.end(), '|', '.');
+		std::replace(name.begin(), name.end(), '#', '$');
 		of << std::format("idaapi.set_name({:#x}, \"{}_{:x}\")\n", ep, name.c_str(), ep);
 		if (stub->Size() == 0)
 			continue;

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -794,7 +794,7 @@ std::string DartDumper::getPoolObjectDescription(intptr_t offset, bool simpleFor
 	else if (objType == dart::ObjectPool::EntryType::kNativeFunction) {
 		auto pc = pool.RawValueAt(idx);
 		uintptr_t start = 0;
-		char* name = dart::NativeSymbolResolver::LookupSymbolName(pc, &start);
+		auto name = dart::NativeSymbolResolver::LookupSymbolName(pc, &start);
 		if (name != NULL) {
 			auto txt = std::format("[pp+{:#x}] NativeFn: {} at {:#x}", offset, name, pc);
 			dart::NativeSymbolResolver::FreeSymbolName(name);

--- a/blutter/src/DartThreadInfo.cpp
+++ b/blutter/src/DartThreadInfo.cpp
@@ -53,7 +53,7 @@ static void initThreadOffsetNames()
 	threadOffsetNames[dart::Thread::dart_stream_offset()] = "dart_stream";
 	//threadOffsetNames[dart::Thread::service_extension_stream_offset()] = "service_extension_stream";
 	threadOffsetNames[dart::Thread::store_buffer_block_offset()] = "store_buffer_block";
-	threadOffsetNames[dart::Thread::marking_stack_block_offset()] = "marking_stack_block";
+	//threadOffsetNames[dart::Thread::marking_stack_block_offset()] = "marking_stack_block"; // removed in Dart 3.5.0 and split into old and new
 	threadOffsetNames[dart::Thread::top_exit_frame_info_offset()] = "top_exit_frame_info";
 	//threadOffsetNames[dart::Thread::heap_offset()] = "heap"; // removed in Dart 3.1.0
 	threadOffsetNames[dart::Thread::top_offset()] = "top";


### PR DESCRIPTION

https://github.com/worawit/blutter/issues/96#issue-2470674670

A dart sdk build error occurs in blutter due to a code change starting from dart 3.5.0.

### dart changes
#### 3.4.4
* char* NativeSymbolResolver::LookupSymbolName(uword pc, uword* start)
* static word marking_stack_block_offset();

#### 3.5.0
* const char* NativeSymbolResolver::LookupSymbolName(uword pc, uword* start)
* static word old_marking_stack_block_offset();
* static word new_marking_stack_block_offset();


