### PR TITLE
WIP: Updated support for radare2

### DIFF
--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -98,15 +98,21 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 
 		std::replace(lib_prefix.begin(), lib_prefix.end(), '$', '_');
 		std::replace(lib_prefix.begin(), lib_prefix.end(), '&', '_');
+		std::replace(lib_prefix.begin(), lib_prefix.end(), '-', '_');
+		std::replace(lib_prefix.begin(), lib_prefix.end(), '+', '_');
 		for (auto cls : lib->classes) {
 			std::string cls_prefix = cls->Name();
 			std::replace(cls_prefix.begin(), cls_prefix.end(), '$', '_');
 			std::replace(cls_prefix.begin(), cls_prefix.end(), '&', '_');
+			std::replace(cls_prefix.begin(), cls_prefix.end(), '-', '_');
+			std::replace(cls_prefix.begin(), cls_prefix.end(), '+', '_');
 			for (auto dartFn : cls->Functions()) {
 				const auto ep = dartFn->Address();
 				auto name = getFunctionName4Ida(*dartFn, cls_prefix);
 				std::replace(name.begin(), name.end(), '$', '_');
 				std::replace(name.begin(), name.end(), '&', '_');
+				std::replace(name.begin(), name.end(), '-', '_');
+				std::replace(name.begin(), name.end(), '+', '_');
 				if (show_library) {
 					of << std::format("CC Library({:#x}) = {} @ {}\n", lib->id, lib_prefix, ep);
 					of << std::format("f lib.{}={:#x} # {:#x}\n", lib_prefix, ep, lib->id);

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -145,7 +145,7 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 					of << std::format("f class.{}.{}={:#x} # {:#x}\n", lib_prefix, cls_prefix, ep, cls->Id());
 					show_class = false;
 				}
-				of << std::format("f method.{}.{}.{}={:#x}\n", lib_prefix, cls_prefix, name.c_str(), ep);
+				of << std::format("f method.{}.{}.{}_{:x}={:#x}\n", lib_prefix, cls_prefix, name.c_str(), ep, ep);
 				if (dartFn->HasMorphicCode()) {
 					of << std::format("f method.{}.{}.{}.miss={:#x}\n", lib_prefix, cls_prefix, name.c_str(), 
 							dartFn->PayloadAddress());
@@ -169,7 +169,7 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 		std::replace(name.begin(), name.end(), '&', '_');
 		std::replace(name.begin(), name.end(), '-', '_');
 		std::replace(name.begin(), name.end(), '+', '_');
-		of << std::format("f method.stub.{}={:#x}\n", name.c_str(), ep);
+		of << std::format("f method.stub.{}_{:x}={:#x}\n", name.c_str(), ep, ep);
 	}
 
 	of << "f pptr=x27\n"; // TODO: hardcoded value

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -87,19 +87,7 @@ static bool is_valid_char(const char ch) {
 		return true;
 	}
 	switch (ch) {
-	case '(':
-	case ')':
-	case '[':
-	case ']':
-	case '<':
-	case '+':
-	case '-':
-	case '>':
-	case '$':
-	case '%':
-	case '@':
 	case '.':
-	case ',':
 	case ':':
 	case '_':
 		return true;
@@ -169,6 +157,21 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 		}
 		show_library = true;
 	}
+	for (auto& item : app.stubs) {
+		auto stub = item.second;
+		const auto ep = stub->Address();
+		std::string name = stub->FullName();
+		std::replace(name.begin(), name.end(), '<', '_');
+		std::replace(name.begin(), name.end(), '>', '_');
+		std::replace(name.begin(), name.end(), ',', '_');
+		std::replace(name.begin(), name.end(), ' ', '_');
+		std::replace(name.begin(), name.end(), '$', '_');
+		std::replace(name.begin(), name.end(), '&', '_');
+		std::replace(name.begin(), name.end(), '-', '_');
+		std::replace(name.begin(), name.end(), '+', '_');
+		of << std::format("f method.stub.{}={:#x}\n", name.c_str(), ep);
+	}
+
 	of << "f pptr=x27\n"; // TODO: hardcoded value
 	auto comments = DumpStructHeaderFile((outDir / "r2_dart_struct.h").string());
 	for (const auto& [offset, comment] : comments) {

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -135,6 +135,7 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 				std::replace(name.begin(), name.end(), '&', '_');
 				std::replace(name.begin(), name.end(), '-', '_');
 				std::replace(name.begin(), name.end(), '+', '_');
+				std::replace(name.begin(), name.end(), '?', '_');
 				if (show_library) {
 					of << std::format("CC Library({:#x}) = {} @ {}\n", lib->id, lib_prefix, ep);
 					of << std::format("f lib.{}={:#x} # {:#x}\n", lib_prefix, ep, lib->id);
@@ -169,6 +170,7 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 		std::replace(name.begin(), name.end(), '&', '_');
 		std::replace(name.begin(), name.end(), '-', '_');
 		std::replace(name.begin(), name.end(), '+', '_');
+		std::replace(name.begin(), name.end(), '?', '_');
 		of << std::format("f method.stub.{}_{:x}={:#x}\n", name.c_str(), ep, ep);
 	}
 

--- a/blutter/src/DartDumper.h
+++ b/blutter/src/DartDumper.h
@@ -8,6 +8,7 @@ public:
 	DartDumper(DartApp& app) : app(app) {};
 
 	void Dump4Ida(std::filesystem::path outDir);
+	void Dump4Radare2(std::filesystem::path outDir);
 
 	std::vector<std::pair<intptr_t, std::string>> DumpStructHeaderFile(std::string outFile);
 

--- a/blutter/src/main.cpp
+++ b/blutter/src/main.cpp
@@ -52,6 +52,7 @@ int main(int argc, char** argv)
 #endif
 		dumper.DumpCode((outDir / "asm").string().c_str());
 		dumper.Dump4Ida(outDir / "ida_script");
+		dumper.Dump4Radare2(outDir / "r2_script");
 
 		std::cout << "Generating Frida script\n";
 		FridaWriter fwriter{ app };


### PR DESCRIPTION
This branch is rebased on top of the current master, but picks the code from https://github.com/worawit/blutter/pull/67, as well as the fixes introduced by @cryptax in https://github.com/worawit/blutter/pull/88 and extends the logic to also flag all the constant pool data, there are few more fixes to be done in r2 to get all the string references to work without depending on the blutter analysis.

Note that this PR also includes the build fix from https://github.com/worawit/blutter/pull/103 otherwise it was failing to compile. 

I have also patches for the Dockerfile that i submitted half a year ago but as long as nothing was merged, i'm quite tempted to just contribute to the @AbhiTheModder fork instead.