### PR TITLE
Fixed crash from analyzing Dart version 3.10.4

### DIFF
--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -192,7 +192,13 @@ std::vector<std::pair<intptr_t, std::string>> DartDumper::DumpStructHeaderFile(s
 				if (unlinkTargetType == dart::ObjectPool::EntryType::kImmediate) {
 					const auto imm = pool.RawValueAt(i + 1);
 					auto dartFn = app.GetFunction(imm - app.base());
-					name = std::format("UnlinkedCall_{:#x}_{:#x}", offset, dartFn->Address(), offset);
+					// if the Dart function does not exist, set name to (no function)
+					if (dartFn) {
+						name = std::format("UnlinkedCall_{:#x}_{:#x}", offset, dartFn->Address());
+					}
+					else {
+						name = std::format("UnlinkedCall_{:#x}_imm_{:#x}_no_function", offset, imm);
+					}
 				}
 				else {
 					ASSERT(unlinkTargetType == dart::ObjectPool::EntryType::kTaggedObject);
@@ -803,7 +809,11 @@ std::string DartDumper::getPoolObjectDescription(intptr_t offset, bool simpleFor
 			if (unlinkTargetType == dart::ObjectPool::EntryType::kImmediate) {
 				const auto imm = pool.RawValueAt(idx + 1);
 				auto dartFn = app.GetFunction(imm - app.base());
-				return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - {}", offset, dartFn->Address(), dartFn->FullName().c_str());
+				// if the Dart function does not exist, set name to (no function)
+				if (dartFn) {
+					return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - {}", offset, dartFn->Address(), dartFn->FullName().c_str());
+				}
+				return std::format("[pp+{:#x}] UnlinkedCall: [imm:{:#x}] (no function)", offset, imm);
 			}
 			else {
 				ASSERT(unlinkTargetType == dart::ObjectPool::EntryType::kTaggedObject);


### PR DESCRIPTION
Hi, I've been working on an Android Flutter app and found that it always crashes when analyzing Dart version 3.10.4

<img width="1041" height="513" alt="image" src="https://github.com/user-attachments/assets/dea3d090-f550-4f16-9596-cfeff7a7373e" />

After a while reading and debugging blutter source code, I found that in the method `DartDumper::getPoolObjectDescription`, some offset will not point to a valid function, making the process crash when dereferencing the `dartFn`. So I added 2 checks to the code to make sure the `dartFn` is not null before continuing the process.

The result should then be success and look like this:

<img width="1032" height="366" alt="image" src="https://github.com/user-attachments/assets/984025b5-0a0a-4179-8cdb-749873e5d349" />

My environment:
- Windows 11
- Python 3.11.9
- Dart 3.10.4, snapshot hash 1ce86630892e2dca9a8543fdb8ed8e22