### PR TITLE
fix: dart 3.11.0+ now requires c++20

### DIFF
--- a/dartvm_fetch_build.py
+++ b/dartvm_fetch_build.py
@@ -128,7 +128,7 @@ def cmake_dart(info: DartLibInfo, target_dir: str):
     with open(CMAKE_TEMPLATE_FILE, 'r') as f:
         code = f.read()
     with open(os.path.join(target_dir, 'CMakeLists.txt'), 'w') as f:
-        f.write(code.replace("VERSION_PLACE_HOLDER", info.version).replace("STD_PLACE_HOLDER", cpp_std))
+        f.write(code.replace('VERSION_PLACE_HOLDER', info.version).replace('STD_PLACE_HOLDER', cpp_std))
 
     # create dartsdk/vx.y.z/Config.cmake.in
     with open(os.path.join(target_dir, 'Config.cmake.in'), 'w') as f:

--- a/dartvm_fetch_build.py
+++ b/dartvm_fetch_build.py
@@ -120,12 +120,15 @@ def checkout_dart(info: DartLibInfo):
     return clonedir
 
 def cmake_dart(info: DartLibInfo, target_dir: str):
+    # Dart 3.11.0+ requires C++20 https://github.com/dart-lang/sdk/commit/3ebbaf08fb9236023b8f37bb9e9de85a9be8e281
+    major, minor = map(int, info.version.split(".")[:2])
+    cpp_std = "20" if (major, minor) >= (3, 11) else "17"
     # On windows, need developer command prompt for x64 (can check with "cl" command)
     # create dartsdk/vx.y.z/CMakefile.list
     with open(CMAKE_TEMPLATE_FILE, 'r') as f:
         code = f.read()
     with open(os.path.join(target_dir, 'CMakeLists.txt'), 'w') as f:
-        f.write(code.replace('VERSION_PLACE_HOLDER', info.version))
+        f.write(code.replace("VERSION_PLACE_HOLDER", info.version).replace("STD_PLACE_HOLDER", cpp_std))
 
     # create dartsdk/vx.y.z/Config.cmake.in
     with open(os.path.join(target_dir, 'Config.cmake.in'), 'w') as f:

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -46,9 +46,8 @@ set(CMAKE_DEBUG_POSTFIX "_d")
 include(sourcelist.cmake)
 add_library(${LIBNAME} STATIC ${SRCS})
 
-# use C++17 because compilation with c++20 is slower
 set_target_properties(${LIBNAME} PROPERTIES
-	CXX_STANDARD 17
+	CXX_STANDARD STD_PLACE_HOLDER
 	CXX_STANDARD_REQUIRED True
 	CXX_VISIBILITY_PRESET hidden
 	CXX_STANDARD_REQUIRED ON


### PR DESCRIPTION
Since Dart 3.11.0, has transitioned to C++20 for bit manipulation. We could revert the C++20 changes (commit), but it’s a temporary fix. It'll just get harder to manage as Dart keeps evolving around that standard.