### PR TITLE
Fix segfault from null GetFunction() in DartDumper for Dart 3.10

### DIFF
--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -192,7 +192,12 @@ std::vector<std::pair<intptr_t, std::string>> DartDumper::DumpStructHeaderFile(s
 				if (unlinkTargetType == dart::ObjectPool::EntryType::kImmediate) {
 					const auto imm = pool.RawValueAt(i + 1);
 					auto dartFn = app.GetFunction(imm - app.base());
-					name = std::format("UnlinkedCall_{:#x}_{:#x}", offset, dartFn->Address(), offset);
+					if (dartFn) {
+						name = std::format("UnlinkedCall_{:#x}_{:#x}", offset, dartFn->Address());
+					}
+					else {
+						name = std::format("UnlinkedCall_{:#x}_{:#x}", offset, imm - app.base());
+					}
 				}
 				else {
 					ASSERT(unlinkTargetType == dart::ObjectPool::EntryType::kTaggedObject);
@@ -486,7 +491,11 @@ std::string DartDumper::ObjectToString(dart::Object& obj, bool simpleForm, bool 
 		return "SubtypeTestCache";
 	case dart::kFunctionCid: {
 		// stub never be in Object Pool
-		auto dartFn = app.GetFunction(dart::Function::Cast(obj).entry_point() - app.base())->AsFunction();
+		auto fnBase = app.GetFunction(dart::Function::Cast(obj).entry_point() - app.base());
+		if (!fnBase) {
+			return std::format("Function({:#x})", dart::Function::Cast(obj).entry_point() - app.base());
+		}
+		auto dartFn = fnBase->AsFunction();
 		if (dartFn->IsClosure()) {
 			auto parentFn = dartFn->GetOutermostFunction();
 			if (parentFn) {
@@ -803,7 +812,12 @@ std::string DartDumper::getPoolObjectDescription(intptr_t offset, bool simpleFor
 			if (unlinkTargetType == dart::ObjectPool::EntryType::kImmediate) {
 				const auto imm = pool.RawValueAt(idx + 1);
 				auto dartFn = app.GetFunction(imm - app.base());
-				return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - {}", offset, dartFn->Address(), dartFn->FullName().c_str());
+				if (dartFn) {
+					return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - {}", offset, dartFn->Address(), dartFn->FullName().c_str());
+				}
+				else {
+					return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - [unknown]", offset, imm - app.base());
+				}
 			}
 			else {
 				ASSERT(unlinkTargetType == dart::ObjectPool::EntryType::kTaggedObject);


### PR DESCRIPTION
## Summary
- Fix SIGSEGV crash during Object Pool dump when processing Dart 3.10.7 snapshots
- `GetFunction()` returns `nullptr` when an UnlinkedCall target address isn't found in the functions/stubs maps, but 3 call sites dereference the result without null checks

## Problem
When running blutter against a Dart 3.10.7 `libapp.so`, the binary crashes with a segmentation fault (signal 11) during `DumpObjectPool()`. The crash occurs in `getPoolObjectDescription()` when handling `UnlinkedCall` entries whose `kImmediate` target address doesn't resolve to any known function.

Related to issue #182 — commit a4d2100 added `kTaggedObject` handling but missed null guards on the `kImmediate` path.

## Changes (all in `blutter/src/DartDumper.cpp`)

| Location | Fix |
|---|---|
| `getPoolObjectDescription()` ~L812 | Added null check on `GetFunction()` return; fallback to `[unknown]` label |
| `DumpStructHeaderFile()` ~L194 | Added null check; also fixed pre-existing extra arg in `std::format()` |
| `ObjectToString()` ~L491 | Split into null check + `AsFunction()` call; fallback to `Function(addr)` |

## Testing
- Verified fix against a Dart 3.10.7 Android arm64 `libapp.so` that previously crashed
- Full run completes successfully: Object Pool dump, code analysis, assembly generation, Frida script output all produced without error