### PR TITLE
Generate Frida script before DartDumper to survive crashes on newer Dart

### DIFF
--- a/blutter/src/main.cpp
+++ b/blutter/src/main.cpp
@@ -35,6 +35,15 @@ int main(int argc, char** argv)
 		app.ExitScope();
 
 		app.EnterScope();
+
+		// Generate Frida script FIRST (only needs app.classes from LoadInfo)
+		std::cerr << "Generating Frida script...\n";
+		std::cerr.flush();
+		FridaWriter fwriter{ app };
+		fwriter.Create((outDir / "blutter_frida.js").string().c_str());
+		std::cerr << "Frida script generated successfully\n";
+		std::cerr.flush();
+
 #ifndef NO_CODE_ANALYSIS
 		std::cout << "Analyzing the application\n";
 		CodeAnalyzer analyzer{ app };
@@ -44,6 +53,7 @@ int main(int argc, char** argv)
 		DartDumper dumper{ app };
 		std::cout << "Dumping Object Pool\n";
 		dumper.DumpObjectPool((outDir / "pp.txt").string().c_str());
+
 		dumper.DumpObjects((outDir / "objs.txt").string().c_str());
 #ifndef NO_CODE_ANALYSIS
 		std::cout << "Generating application assemblies\n";
@@ -52,10 +62,6 @@ int main(int argc, char** argv)
 #endif
 		dumper.DumpCode((outDir / "asm").string().c_str());
 		dumper.Dump4Ida(outDir / "ida_script");
-
-		std::cout << "Generating Frida script\n";
-		FridaWriter fwriter{ app };
-		fwriter.Create((outDir / "blutter_frida.js").string().c_str());
 
 		app.ExitScope();
 	}


### PR DESCRIPTION
## Summary

- Moves `FridaWriter::Create()` to run immediately after `app.EnterScope()`, before any `DartDumper` calls
- `blutter_frida.js` (the Classes[] array) is now generated first, so it survives if DartDumper crashes
- Uses `stderr` with explicit flush for status messages (stdout doesn't flush before SIGSEGV)

## Problem

On Dart 3.10.8 (stable, Jan 2026) Android arm64 snapshots, `DartDumper` consistently SIGSEGV's during `DumpObjects()` or `DumpCode()`. The object pool (`pp.txt`) is written successfully, but `blutter_frida.js` was never reached because it ran after DartDumper.

This means the most critical output for Frida-based instrumentation — the Classes[] array with all ~4800 app classes — was lost even though it has zero dependency on the crashing code.

## Why this is safe

`FridaWriter::Create()` only depends on `app.classes` populated by `LoadInfo()`. It does **not** use any output from `CodeAnalyzer` or `DartDumper`. Moving it earlier has no effect on correctness — it generates identical output regardless of position.

## Tested on

- Dart 3.10.8 (stable) Android arm64 snapshot
- `--no-analysis` mode: pp.txt + blutter_frida.js both generated successfully before SIGSEGV in DartDumper
- blutter_frida.js: 5,122 lines, 4,810 classes extracted correctly