### PR TITLE
Fix IDA script invalid labels + Add Frida Closure/Map/Set support

### DIFF
--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -96,11 +96,20 @@ void DartDumper::Dump4Ida(std::filesystem::path outDir)
 			for (auto dartFn : cls->Functions()) {
 				const auto ep = dartFn->Address();
 				auto name = getFunctionName4Ida(*dartFn, cls_prefix);
-				of << std::format("ida_funcs.add_func({:#x}, {:#x})\n", ep, ep + dartFn->Size());
+				const auto fnSize = dartFn->Size();
+				if (fnSize > 0) {
+					of << std::format("ida_funcs.add_func({:#x}, {:#x})\n", ep, ep + fnSize);
+				}
 				of << std::format("idaapi.set_name({:#x}, \"{}_{}::{}_{:x}\")\n", ep, lib_prefix, cls_prefix, name.c_str(), ep);
 				if (dartFn->HasMorphicCode()) {
-					of << std::format("idaapi.set_name({:#x}, \"{}_{}::{}_{:x}_miss\")\n", dartFn->PayloadAddress(), lib_prefix, cls_prefix, name.c_str(), ep);
-					of << std::format("idaapi.set_name({:#x}, \"{}_{}::{}_{:x}_check\")\n", dartFn->MonomorphicAddress(), lib_prefix, cls_prefix, name.c_str(), ep);
+					const auto payloadAddr = dartFn->PayloadAddress();
+					const auto morphicAddr = dartFn->MonomorphicAddress();
+					if (payloadAddr != 0 && payloadAddr != ep) {
+						of << std::format("idaapi.set_name({:#x}, \"{}_{}::{}_{:x}_miss\")\n", payloadAddr, lib_prefix, cls_prefix, name.c_str(), ep);
+					}
+					if (morphicAddr != 0 && morphicAddr != ep && morphicAddr != payloadAddr) {
+						of << std::format("idaapi.set_name({:#x}, \"{}_{}::{}_{:x}_check\")\n", morphicAddr, lib_prefix, cls_prefix, name.c_str(), ep);
+					}
 				}
 			}
 		}

--- a/scripts/frida.template.js
+++ b/scripts/frida.template.js
@@ -113,6 +113,57 @@ function getDartTypedArrayValues(ptr, cls, elementSize, readValFn) {
     return vals;
 }
 
+function getDartClosure(ptr, cls) {
+    let ep = ptr.add(cls.epOffset).readPointer();
+    let fnName = 'unknown';
+    if (libapp !== null) {
+        let offset = ep.sub(libapp);
+        fnName = 'fn_' + offset.toString(16);
+    }
+    return `Closure(${fnName})`;
+}
+
+function getDartLinkedHashData(ptr, cls, depthLeft, isMap) {
+    const usedData = ptr.add(cls.usedOffset).readU32() >> 1;
+    let arrPtr = ptr.add(cls.dataOffset);
+    let dataCls = Classes[CidArray];
+
+    if (isMap) {
+        let result = {};
+        for (let i = 0; i < usedData; i += 2) {
+            try {
+                let keyPtr = arrPtr.add(dataCls.dataOffset + i * CompressedWordSize).readPointer();
+                let valPtr = arrPtr.add(dataCls.dataOffset + (i + 1) * CompressedWordSize).readPointer();
+                const [kTptr, kCls, kVal] = getTaggedObjectValue(keyPtr, depthLeft - 1);
+                const [vTptr, vCls, vVal] = getTaggedObjectValue(valPtr, depthLeft - 1);
+                if (kCls.id === CidNull) continue;
+                let keyStr = (kCls.id === CidString || kCls.id === CidTwoByteString) ? kVal : `${kCls.name}@${kTptr.toString().slice(2)}`;
+                result[keyStr] = vVal;
+            } catch(e) { break; }
+        }
+        return result;
+    } else {
+        let items = [];
+        for (let i = 0; i < usedData; i++) {
+            try {
+                let valPtr = arrPtr.add(dataCls.dataOffset + i * CompressedWordSize).readPointer();
+                const [vTptr, vCls, vVal] = getTaggedObjectValue(valPtr, depthLeft - 1);
+                if (vCls.id === CidNull) continue;
+                items.push(vVal);
+            } catch(e) { break; }
+        }
+        return items;
+    }
+}
+
+function getDartMap(ptr, cls, depthLeft) {
+    return getDartLinkedHashData(ptr, cls, depthLeft, true);
+}
+
+function getDartSet(ptr, cls, depthLeft) {
+    return getDartLinkedHashData(ptr, cls, depthLeft, false);
+}
+
 function isFieldNative(fieldBitmap, offset) {
     const idx = offset / CompressedWordSize;
     return (fieldBitmap & (1 << idx)) !== 0;
@@ -157,6 +208,12 @@ function getObjectValue(ptr, cls, depthLeft = MaxDepth) {
         return getDartTypedArrayValues(ptr, cls, 8, (p) => p.readU64());
     case CidInt64Array:
         return getDartTypedArrayValues(ptr, cls, 8, (p) => p.readS64());
+    case CidClosure:
+        return getDartClosure(ptr, cls);
+    case CidSet:
+        return getDartSet(ptr, cls, depthLeft);
+    case CidMap:
+        return getDartMap(ptr, cls, depthLeft);
     }
 
     if (cls.id < NumPredefinedCids) {


### PR DESCRIPTION
## IDA Script Fix (`DartDumper.cpp`)

When analyzing obfuscated apps, the generated `addNames.py` had issues:

- **`set_name(0x0, ...)`** — 5206 `_miss` labels pointed to address 0x0 because `PayloadAddress()` returns 0 for functions with no code body. These all overwrote each other at address 0.
- **`set_name(0x320080, ...)`** — 5207 `_check` labels pointed to the same shared `MonomorphicAddress`, overwriting each other.
- **`add_func(addr, addr)`** — 5206 functions had zero size (start == end), giving IDA no boundary information.

Fix: validate addresses before emitting labels, skip `add_func` when size ≤ 0.

## Frida Template Fix (`frida.template.js`)

`getObjectValue()` did not handle `Closure`, `Map`, or `Set` types. These fell through to `"Unhandle class id"` error despite having CID constants and struct offsets already exported.

Added:
- `getDartClosure()` — reads closure's function entry point
- `getDartMap()` / `getDartSet()` — reads LinkedHashBase data array
- `CidClosure`, `CidMap`, `CidSet` cases in `getObjectValue()` switch

Tested with obfuscated Flutter app (Dart 3.5.4, arm64).