### PR TITLE
Fix ARM64 analyzer assertion failures for Dart 3.10.4 and 3.11.1

### DIFF
--- a/blutter/src/CodeAnalyzer_arm64.cpp
+++ b/blutter/src/CodeAnalyzer_arm64.cpp
@@ -4,6 +4,7 @@
 #include "VarValue.h"
 #include "DartThreadInfo.h"
 #include <source_location>
+#include <unordered_set>
 
 #ifndef NO_CODE_ANALYSIS
 
@@ -194,6 +195,48 @@ static inline void handleExtraDecompressPointer(AsmIterator& insn, arm64_reg reg
 	if (!(insn.ops(0).reg == insn.ops(1).reg && insn.ops(0).reg == reg)) return;
 	if (!(insn.ops(2).reg == CSREG_DART_HEAP && insn.ops(2).shift.value == 32)) return;
 	++insn;
+}
+
+// Handle leave-frame restore patterns for newer Dart ARM64 codegen.
+// Accepted patterns:
+// - ldp fp, lr, [sp], #16
+// - mov tmp, fp/x29 ; ldr fp, [tmp], #8
+static bool tryConsumeLeaveFrameRestore(AsmIterator& insn)
+{
+	if (insn.id() == ARM64_INS_LDP) {
+		if (insn.op_count() < 3 || insn.op_count() > 4)
+			return false;
+		if (insn.ops(0).reg != CSREG_DART_FP || insn.ops(1).reg != ARM64_REG_LR)
+			return false;
+		if (insn.ops(2).mem.base != CSREG_DART_SP)
+			return false;
+		if (insn.op_count() == 4 && (insn.ops(3).type != ARM64_OP_IMM || insn.ops(3).imm != 0x10))
+			return false;
+		++insn;
+		return true;
+	}
+
+	// New compatibility path: tmp must be proven from fp immediately before ldr.
+	if (insn.id() == ARM64_INS_MOV && insn.ops(1).type == ARM64_OP_REG &&
+		(insn.ops(1).reg == CSREG_DART_FP || insn.ops(1).reg == ARM64_REG_X29))
+	{
+		const auto tmpReg = insn.ops(0).reg;
+		if (tmpReg == CSREG_DART_FP)
+			return false;
+		++insn;
+		if (!(insn.id() == ARM64_INS_LDR && insn.writeback()))
+			return false;
+		if (insn.ops(0).reg != CSREG_DART_FP)
+			return false;
+		if (insn.op_count() < 3 || insn.ops(1).mem.base != tmpReg)
+			return false;
+		if (insn.ops(2).type != ARM64_OP_IMM || insn.ops(2).imm != 8)
+			return false;
+		++insn;
+		return true;
+	}
+
+	return false;
 }
 
 struct ILResult {
@@ -481,13 +524,8 @@ std::unique_ptr<LeaveFrameInstr> FunctionAnalyzer::processLeaveFrameInstr(AsmIte
 		INSN_ASSERT(fnInfo->useFramePointer);
 		const auto ins0_addr = insn.address();
 		++insn;
-
-		INSN_ASSERT(insn.id() == ARM64_INS_LDP && insn.op_count() == 4);
-		INSN_ASSERT(insn.ops(0).reg == CSREG_DART_FP);
-		INSN_ASSERT(insn.ops(1).reg == ARM64_REG_LR);
-		INSN_ASSERT(insn.ops(2).mem.base == CSREG_DART_SP);
-		INSN_ASSERT(insn.ops(3).imm == 0x10);
-		++insn;
+		if (!tryConsumeLeaveFrameRestore(insn))
+			return nullptr;
 
 		return std::make_unique<LeaveFrameInstr>(insn.Wrap(ins0_addr));
 	}
@@ -1613,6 +1651,11 @@ static bool isAllowedParameterRegister(A64::Register reg)
 	return std::find(std::begin(allowedParameterRegisters), eptr, reg) != eptr;
 }
 
+static bool isTmpForwardingRegister(A64::Register reg)
+{
+	return reg == A64::Register::TMP || reg == A64::Register::TMP2 || reg == A64::Register::VTMP;
+}
+
 void FunctionAnalyzer::handleParameterRegisters(AsmIterator& insn)
 {
 	// since Dart 3.4, some function call might use register for passing parameters
@@ -1642,51 +1685,93 @@ void FunctionAnalyzer::handleParameterRegisters(AsmIterator& insn)
 		return paramRegs.back();
 	};
 
+	// Short-lived alias map for newer Dart ARM64 tmp register forwarding.
+	// The map is valid only in this local parameter shuffling window.
+	std::unordered_map<int32_t, A64::Register> aliases;
+	const auto clearAliases = [&] {
+		aliases.clear();
+	};
+	const auto killAlias = [&](A64::Register reg) {
+		aliases.erase((int32_t)reg.value());
+	};
+	const auto setAlias = [&](A64::Register dst, A64::Register src) {
+		aliases[(int32_t)dst.value()] = src;
+	};
+	const auto resolveAlias = [&](A64::Register reg) {
+		A64::Register curr = reg;
+		for (int i = 0; i < 8; i++) {
+			const auto it = aliases.find((int32_t)curr.value());
+			if (it == aliases.end() || it->second == curr)
+				break;
+			curr = it->second;
+		}
+		return curr;
+	};
+
 	while (true) {
 		// Note: no need to check register is not defined before used because this function is called before any register is set
 		if (insn.id() == ARM64_INS_MOV && insn.ops(1).type == ARM64_OP_REG && insn.ops(1).reg != CSREG_DART_NULL) {
 			// src must be undefined
 			const A64::Register srcReg = insn.ops(1).reg;
 			const A64::Register dstReg = insn.ops(0).reg;
-
-			const bool isTmpReg = srcReg == A64::Register::TMP || srcReg == A64::Register::VTMP;
-			if (!isTmpReg && !isAllowedParameterRegister(srcReg))
+			const auto resolvedSrcReg = resolveAlias(srcReg);
+			const bool isResolvedParamReg = isAllowedParameterRegister(resolvedSrcReg);
+			const bool isResolvedTmpReg = isTmpForwardingRegister(resolvedSrcReg);
+			if (!isResolvedParamReg && !isResolvedTmpReg)
 				break;
 
-			auto& param = getParamReg(srcReg);
-			if (param.dstReg.IsSet()) {
-				// dstReg is already set. if using same source, ignore them
-				// TODO: multiple dstReg
-				if (param.reg == srcReg) {
-					++insn;
-					continue;
+			// kill-on-overwrite for alias tracking
+			killAlias(dstReg);
+
+			if (isResolvedParamReg) {
+				auto& param = getParamReg(resolvedSrcReg);
+				if (param.dstReg.IsSet()) {
+					// dstReg is already set. if using same source, ignore them
+					// TODO: multiple dstReg
+					if (param.reg == resolvedSrcReg && (srcReg == resolvedSrcReg || param.dstReg == srcReg)) {
+						setAlias(dstReg, resolvedSrcReg);
+						++insn;
+						continue;
+					}
+					if (param.dstReg != srcReg && param.dstReg != resolvedSrcReg) {
+						// avoid propagating unconstrained aliases through unrelated shuffles
+						clearAliases();
+						break;
+					}
 				}
-				INSN_ASSERT(param.dstReg == srcReg);
+				param.dstReg = dstReg;
+				setAlias(dstReg, resolvedSrcReg);
 			}
 			else {
-				// tmp reg cannot be found from parameter register
-				INSN_ASSERT(!isTmpReg);
+				// keep forwarding alias only; no parameter binding until source is resolved.
+				setAlias(dstReg, resolvedSrcReg);
 			}
-			param.dstReg = dstReg;
 
 			++insn;
 		}
 		else if (insn.id() == ARM64_INS_STUR && insn.ops(1).mem.base == CSREG_DART_FP && insn.ops(1).mem.disp < 0) {
 			// src must be undefined, but might be used with mov instruction
 			const A64::Register srcReg = insn.ops(0).reg;
-			if (fnInfo->State()->GetValue(srcReg) != nullptr || !isAllowedParameterRegister(srcReg))
+			const auto resolvedSrcReg = resolveAlias(srcReg);
+			if (fnInfo->State()->GetValue(srcReg) != nullptr || !isAllowedParameterRegister(resolvedSrcReg))
 				break;
 
 			const int offset = insn.ops(1).mem.disp;
-			auto& param = getParamReg(srcReg);
+			auto& param = getParamReg(resolvedSrcReg);
 			INSN_ASSERT(param.localOffset == 0);
 			param.localOffset = offset;
 			++insn;
 		}
 		else {
+			// Do not let alias map leak across calls/control-flow or unrelated instruction windows.
+			if (insn.id() == ARM64_INS_BL || insn.id() == ARM64_INS_BLR || insn.id() == ARM64_INS_RET || insn.IsBranch())
+				clearAliases();
+			else if (insn.op_count() > 0 && insn.ops(0).type == ARM64_OP_REG)
+				killAlias(A64::Register{ insn.ops(0).reg });
 			break;
 		}
 	}
+	clearAliases();
 
 	if (!paramRegs.empty()) {
 		// sort paramRegs first
@@ -2058,14 +2143,80 @@ std::unique_ptr<SetupParametersInstr> FunctionAnalyzer::processPrologueParameter
 	}
 
 	if (insn.address() < endPrologueAddr) {
-		// moving registers
-		while (insn.id() == ARM64_INS_MOV && insn.ops(1).type == ARM64_OP_REG && insn.ops(1).reg != CSREG_DART_NULL) {
-			const A64::Register srcReg = insn.ops(1).reg;
-			const A64::Register dstReg = insn.ops(0).reg;
-			const auto val = fnInfo->State()->MoveRegister(dstReg, srcReg);
-			INSN_ASSERT(val != nullptr);
-			++insn;
-		}
+		// short-lived aliases for prologue parameter register shuffle
+		std::unordered_map<int32_t, A64::Register> aliases;
+		std::unordered_map<int32_t, int> incomingParamIdxByReg;
+		std::unordered_set<int> usedParamIdx;
+		const auto clearAliases = [&] {
+			aliases.clear();
+		};
+		const auto killAlias = [&](A64::Register reg) {
+			aliases.erase((int32_t)reg.value());
+		};
+		const auto setAlias = [&](A64::Register dst, A64::Register src) {
+			aliases[(int32_t)dst.value()] = src;
+		};
+		const auto resolveAlias = [&](A64::Register reg) {
+			A64::Register curr = reg;
+			for (int i = 0; i < 8; i++) {
+				const auto it = aliases.find((int32_t)curr.value());
+				if (it == aliases.end() || it->second == curr)
+					break;
+				curr = it->second;
+			}
+			return curr;
+		};
+		const auto findExistingParamIdx = [&](A64::Register reg) {
+			for (int i = 0; i < fnInfo->params.NumParam(); i++) {
+				if (fnInfo->params[i].valReg == reg || fnInfo->params[i].paramReg == reg)
+					return i;
+			}
+			return -1;
+		};
+		const auto ensureIncomingParamValue = [&](A64::Register reg) -> VarValue* {
+			const auto rootReg = resolveAlias(reg);
+			if (!isAllowedParameterRegister(rootReg))
+				return nullptr;
+
+			int paramIdx = -1;
+			const auto key = (int32_t)rootReg.value();
+			const auto it = incomingParamIdxByReg.find(key);
+			if (it != incomingParamIdxByReg.end()) {
+				paramIdx = it->second;
+			}
+			else {
+				paramIdx = findExistingParamIdx(rootReg);
+				if (paramIdx < 0) {
+					for (int i = 0; i < fnInfo->params.NumParam(); i++) {
+						if (usedParamIdx.find(i) == usedParamIdx.end()) {
+							paramIdx = i;
+							break;
+						}
+					}
+				}
+				if (paramIdx < 0) {
+					paramIdx = fnInfo->params.NumParam();
+					fnInfo->params.add(FnParamInfo{ rootReg });
+				}
+				else if (!fnInfo->params[paramIdx].valReg.IsSet()) {
+					fnInfo->params[paramIdx].valReg = rootReg;
+				}
+				incomingParamIdxByReg[key] = paramIdx;
+				usedParamIdx.insert(paramIdx);
+			}
+			return fnInfo->Vars()->ValParam(paramIdx);
+		};
+		const auto resolveParamValueFromReg = [&](A64::Register reg) -> VarValue* {
+			if (auto val = fnInfo->State()->GetValue(reg); val != nullptr)
+				return val;
+			const auto rootReg = resolveAlias(reg);
+			if (rootReg != reg) {
+				if (auto val = fnInfo->State()->GetValue(rootReg); val != nullptr)
+					return val;
+			}
+			return ensureIncomingParamValue(rootReg);
+		};
+
 		// before CheckStackOverflow, there might be loading paramters into registers and storing some register to local stack
 		// the parameter might be loaded to a register
 		while (insn.id() == ARM64_INS_LDR && insn.ops(1).mem.base == CSREG_DART_FP && insn.ops(1).mem.disp > 0) {
@@ -2082,50 +2233,96 @@ std::unique_ptr<SetupParametersInstr> FunctionAnalyzer::processPrologueParameter
 			fnInfo->State()->SetRegister(dst_reg, fnInfo->Vars()->ValParam(paramIdx));
 		}
 		handleInitialization();
-		// the value might be saved to stack as if it is a local variable but with fixed negative offset from FP
-		while (true) {
-			const auto storeRes = handleStoreLocal(insn);
-			if (storeRes.fpOffset == 0)
-				break;
 
-			const auto srcReg = A64::Register{ storeRes.srcReg };
-			if (fnInfo->typeArgumentReg == srcReg) {
-				fnInfo->typeArgumentLocalOffset = storeRes.fpOffset;
-			}
-			else if (fnInfo->closureContextReg == srcReg) {
-				fnInfo->closureContextLocalOffset = storeRes.fpOffset;
-			}
-			else {
-				auto val = fnInfo->State()->GetValue(srcReg);
+		while (true) {
+			bool progressed = false;
+
+			// moving registers (support short-lived tmp shuffle chains in prologue)
+			while (insn.id() == ARM64_INS_MOV && insn.ops(1).type == ARM64_OP_REG && insn.ops(1).reg != CSREG_DART_NULL) {
+				const A64::Register srcReg = insn.ops(1).reg;
+				const A64::Register dstReg = insn.ops(0).reg;
+				killAlias(dstReg);
+				auto val = resolveParamValueFromReg(srcReg);
 				if (val == nullptr) {
-					std::cout << std::format("Cannot find define of srcReg\n");
-					auto ins = insn.Current() - 1;
-					std::cout << std::format("  {:#x}: {} {}\n", ins->address, &ins->mnemonic[0], &ins->op_str[0]);
+					const auto rootReg = resolveAlias(srcReg);
+					if (!isTmpForwardingRegister(rootReg)) {
+						clearAliases();
+						break;
+					}
+					// unresolved tmp forwarding yet, keep alias and continue.
+					setAlias(dstReg, rootReg);
+					fnInfo->State()->ClearRegister(dstReg);
 				}
-				fnInfo->State()->SetLocal(storeRes.fpOffset, val);
+				else {
+					const auto rootReg = resolveAlias(srcReg);
+					fnInfo->State()->SetRegister(dstReg, val);
+					if (dstReg != srcReg)
+						fnInfo->State()->ClearRegister(srcReg);
+					setAlias(dstReg, rootReg);
+				}
+				++insn;
+				progressed = true;
+			}
+
+			// the value might be saved to stack as if it is a local variable but with fixed negative offset from FP
+			while (true) {
+				const auto storeRes = handleStoreLocal(insn);
+				if (storeRes.fpOffset == 0)
+					break;
+				progressed = true;
+
+				const auto srcReg = A64::Register{ storeRes.srcReg };
+				if (fnInfo->typeArgumentReg == srcReg) {
+					fnInfo->typeArgumentLocalOffset = storeRes.fpOffset;
+				}
+				else if (fnInfo->closureContextReg == srcReg) {
+					fnInfo->closureContextLocalOffset = storeRes.fpOffset;
+				}
+				else {
+					auto val = resolveParamValueFromReg(srcReg);
+					if (val != nullptr) {
+						fnInfo->State()->SetLocal(storeRes.fpOffset, val);
+					}
+					// unknown spill source: gracefully degrade and continue.
+				}
+			}
+
+			if (!progressed)
+				break;
+			if (insn.id() == ARM64_INS_BL || insn.id() == ARM64_INS_BLR || insn.id() == ARM64_INS_RET || insn.IsBranch()) {
+				clearAliases();
+				break;
 			}
 		}
+		clearAliases();
 	}
 
 	// set all parameter register value and local variable
-	if (!fnInfo->params.empty()) {
-		// clear all valRegs in param first
-		for (auto& param : fnInfo->params.params) {
-			param.valReg = A64::Register{};
-			param.localOffset = 0;
+	const auto ensureParamInfoSize = [&](int idx) {
+		while (fnInfo->params.NumParam() <= idx) {
+			fnInfo->params.add(FnParamInfo{});
 		}
-		const auto& local_vars = fnInfo->State()->local_vars;
-		for (auto i = 0; i < local_vars.size(); i++) {
-			const auto local = local_vars[i];
-			if (local && local->RawTypeId() == VarValue::Parameter) {
-				fnInfo->params[local->AsParam()->idx].localOffset = AnalyzingState::indexToLocalOffset(i);
-			}
+	};
+	// clear all valRegs in param first
+	for (auto& param : fnInfo->params.params) {
+		param.valReg = A64::Register{};
+		param.localOffset = 0;
+	}
+	const auto& local_vars = fnInfo->State()->local_vars;
+	for (auto i = 0; i < local_vars.size(); i++) {
+		const auto local = local_vars[i];
+		if (local && local->RawTypeId() == VarValue::Parameter) {
+			const auto idx = local->AsParam()->idx;
+			ensureParamInfoSize(idx);
+			fnInfo->params[idx].localOffset = AnalyzingState::indexToLocalOffset(i);
 		}
-		auto& regs = fnInfo->State()->regs;
-		for (auto i = 0; i < A64::Register::kNumberOfRegisters; i++) {
-			if (regs[i] && regs[i]->RawTypeId() == VarValue::Parameter) {
-				fnInfo->params[regs[i]->AsParam()->idx].valReg = A64::Register::Value{ i };
-			}
+	}
+	auto& regs = fnInfo->State()->regs;
+	for (auto i = 0; i < A64::Register::kNumberOfRegisters; i++) {
+		if (regs[i] && regs[i]->RawTypeId() == VarValue::Parameter) {
+			const auto idx = regs[i]->AsParam()->idx;
+			ensureParamInfoSize(idx);
+			fnInfo->params[idx].valReg = A64::Register::Value{ i };
 		}
 	}
 
@@ -2724,15 +2921,11 @@ std::unique_ptr<BoxInt64Instr> FunctionAnalyzer::processBoxInt64Instr(AsmIterato
 
 			if (doEnterFrame) {
 				// MUST have LeaveFrame here
-				INSN_ASSERT(insn.id() == ARM64_INS_MOV && insn.ops(0).reg == CSREG_DART_SP && insn.ops(1).reg == CSREG_DART_FP);
+				if (!(insn.id() == ARM64_INS_MOV && insn.ops(0).reg == CSREG_DART_SP && insn.ops(1).reg == CSREG_DART_FP))
+					return nullptr;
 				++insn;
-
-				INSN_ASSERT(insn.id() == ARM64_INS_LDP && insn.op_count() == 4);
-				INSN_ASSERT(insn.ops(0).reg == CSREG_DART_FP);
-				INSN_ASSERT(insn.ops(1).reg == ARM64_REG_LR);
-				INSN_ASSERT(insn.ops(2).mem.base == CSREG_DART_SP);
-				INSN_ASSERT(insn.ops(3).imm == 0x10);
-				++insn;
+				if (!tryConsumeLeaveFrameRestore(insn))
+					return nullptr;
 			}
 
 			INSN_ASSERT(insn.id() == ARM64_INS_STUR);
@@ -3215,34 +3408,63 @@ std::unique_ptr<ILInstr> FunctionAnalyzer::processLoadStore(AsmIterator& insn)
 
 			const auto objReg = A64::Register{ dart::kWriteBarrierObjectReg };
 			const auto valReg = A64::Register{ dart::kWriteBarrierValueReg };
+			const int64_t arrayDataOffset = dart::Array::data_offset() - dart::kHeapObjectTag;
 			// TODO: objReg type MUST be Dart array
 			auto idx = VarStorage::NewSmallImm(0);
+			bool hasExplicitArrayDataOffset = false;
 			if (insn.ops(2).type == ARM64_OP_IMM) {
 				// const int64_t offset = index * index_scale + HeapDataOffset(is_external, cid);
 				const auto arr_idx = (insn.ops(2).imm + dart::kHeapObjectTag - dart::Array::data_offset()) / dart::kCompressedWordSize;
 				if (arr_idx < 0)
 					return nullptr;
 				idx = VarStorage::NewSmallImm(arr_idx);
+				hasExplicitArrayDataOffset = true; // offset is folded into immediate in first ADD
 				++insn;
 			}
 			else {
 				// register as index
-				INSN_ASSERT(insn.ops(2).shift.type == ARM64_SFT_LSL &&
-					(insn.ops(2).shift.value == dart::kCompressedWordSizeLog2 ||
-						(insn.ops(2).shift.value == dart::kCompressedWordSizeLog2 - 1 || insn.ops(2).ext == ARM64_EXT_SXTW)));
+				const auto shift = insn.ops(2).shift;
+				const auto ext = insn.ops(2).ext;
+				const bool shiftCompatible =
+					(shift.type == ARM64_SFT_LSL &&
+						(shift.value == dart::kCompressedWordSizeLog2 || shift.value == dart::kCompressedWordSizeLog2 - 1)) ||
+					(shift.type == ARM64_SFT_INVALID &&
+						(ext == ARM64_EXT_INVALID || ext == ARM64_EXT_SXTW || ext == ARM64_EXT_UXTW));
+				if (!shiftCompatible)
+					return nullptr;
 				idx = VarStorage(A64::Register{ insn.ops(2).reg });
 				++insn;
 
-				INSN_ASSERT(insn.id() == ARM64_INS_ADD);
-				INSN_ASSERT(insn.ops(0).reg == CSREG_DART_WB_SLOT);
-				INSN_ASSERT(insn.ops(1).reg == CSREG_DART_WB_SLOT);
-				INSN_ASSERT(insn.ops(2).imm == dart::Array::data_offset() - dart::kHeapObjectTag);
-				++insn;
+				// newer Dart ARM64 may fold data offset into STR mem.disp
+				if (insn.id() == ARM64_INS_ADD && insn.ops(0).reg == CSREG_DART_WB_SLOT &&
+					insn.ops(1).reg == CSREG_DART_WB_SLOT && insn.ops(2).type == ARM64_OP_IMM)
+				{
+					if (insn.ops(2).imm != arrayDataOffset)
+						return nullptr;
+					hasExplicitArrayDataOffset = true;
+					++insn;
+				}
 			}
 
-			INSN_ASSERT(insn.id() == ARM64_INS_STR);
-			INSN_ASSERT(A64::Register{ insn.ops(0).reg } == valReg && GetCsRegSize(insn.ops(0).reg) == dart::kCompressedWordSize);
-			INSN_ASSERT(insn.ops(1).mem.base == CSREG_DART_WB_SLOT && insn.ops(1).mem.disp == 0);
+			if (insn.id() != ARM64_INS_STR)
+				return nullptr;
+			if (A64::Register{ insn.ops(0).reg } != valReg || GetCsRegSize(insn.ops(0).reg) != dart::kCompressedWordSize)
+				return nullptr;
+			if (insn.ops(1).mem.base != CSREG_DART_WB_SLOT)
+				return nullptr;
+			const auto storeDisp = insn.ops(1).mem.disp;
+			// Positive invariant: emit array-element store only when data offset is explicitly consumed
+			// or provably folded into STR displacement.
+			if (hasExplicitArrayDataOffset) {
+				if (storeDisp != 0)
+					return nullptr;
+			}
+			else if (storeDisp == arrayDataOffset) {
+				// data offset folded in STR addressing
+			}
+			else {
+				return nullptr;
+			}
 			++insn;
 
 			const auto il_wb = processWriteBarrierInstr(insn);

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -192,7 +192,12 @@ std::vector<std::pair<intptr_t, std::string>> DartDumper::DumpStructHeaderFile(s
 				if (unlinkTargetType == dart::ObjectPool::EntryType::kImmediate) {
 					const auto imm = pool.RawValueAt(i + 1);
 					auto dartFn = app.GetFunction(imm - app.base());
-					name = std::format("UnlinkedCall_{:#x}_{:#x}", offset, dartFn->Address(), offset);
+					if (dartFn != nullptr) {
+						name = std::format("UnlinkedCall_{:#x}_{:#x}", offset, dartFn->Address(), offset);
+					}
+					else {
+						name = std::format("UnlinkedCall_{:#x}_unknown", offset);
+					}
 				}
 				else {
 					ASSERT(unlinkTargetType == dart::ObjectPool::EntryType::kTaggedObject);
@@ -486,7 +491,11 @@ std::string DartDumper::ObjectToString(dart::Object& obj, bool simpleForm, bool 
 		return "SubtypeTestCache";
 	case dart::kFunctionCid: {
 		// stub never be in Object Pool
-		auto dartFn = app.GetFunction(dart::Function::Cast(obj).entry_point() - app.base())->AsFunction();
+		auto fnBase = app.GetFunction(dart::Function::Cast(obj).entry_point() - app.base());
+		if (fnBase == nullptr || fnBase->IsStub()) {
+			return std::format("Function: [unknown] ({:#x})", dart::Function::Cast(obj).entry_point() - app.base());
+		}
+		auto dartFn = fnBase->AsFunction();
 		if (dartFn->IsClosure()) {
 			auto parentFn = dartFn->GetOutermostFunction();
 			if (parentFn) {
@@ -803,7 +812,12 @@ std::string DartDumper::getPoolObjectDescription(intptr_t offset, bool simpleFor
 			if (unlinkTargetType == dart::ObjectPool::EntryType::kImmediate) {
 				const auto imm = pool.RawValueAt(idx + 1);
 				auto dartFn = app.GetFunction(imm - app.base());
-				return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - {}", offset, dartFn->Address(), dartFn->FullName().c_str());
+				if (dartFn != nullptr) {
+					return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - {}", offset, dartFn->Address(), dartFn->FullName().c_str());
+				}
+				else {
+					return std::format("[pp+{:#x}] UnlinkedCall: {:#x} - [unknown function]", offset, imm - app.base());
+				}
 			}
 			else {
 				ASSERT(unlinkTargetType == dart::ObjectPool::EntryType::kTaggedObject);


### PR DESCRIPTION
## Summary

This PR fixes ARM64 analyzer assertion failures and follow-up crashes when processing Dart 3.10.4 and 3.11.1 binaries.

In addition to the analyzer changes, it also hardens object-pool dumping paths against null function lookups that could otherwise crash during output generation.

## Root cause

There were two main classes of failures:

1. **Overly strict ARM64 pattern assumptions in the analyzer**
   - Several analyzer paths assumed a single instruction shape and asserted when newer Dart ARM64 codegen emitted equivalent patterns in a different form.
   - Prologue parameter handling assumed source registers were already defined before register shuffles / spills.
   - Leave-frame matching assumed only a strict `LDP`-based restore form.
   - WB-slot array-store matching assumed specific shift / add sequences.

2. **Null dereference risk in object-pool dumping**
   - Some object-pool dumping paths dereferenced the result of `app.GetFunction(...)` without checking for null first.

## Changes

### `blutter/src/CodeAnalyzer_arm64.cpp`

- Added guarded leave-frame restore parsing to support both:
  - the traditional `LDP` restore pattern, and
  - the newer `MOV tmp, fp/x29` + `LDR fp, [tmp], #8` form.
- Updated leave-frame consumers to gracefully degrade instead of asserting on unrecognized but non-provable patterns.
- Improved temporary-register forwarding handling used in parameter setup logic:
  - supports short-lived alias tracking,
  - clears aliases at control-flow / call boundaries,
  - avoids hard assertion failures on tmp-register forwarding patterns.
- Reworked prologue parameter handling so incoming parameter values can still be resolved through short register-move / spill chains instead of requiring a pre-existing local define.
- Tightened WB-slot array-store recognition so `StoreArrayElementInstr` is only emitted when the required address/data-offset semantics can actually be proven; otherwise the matcher degrades safely.

### `blutter/src/DartDumper.cpp`

- Added null checks around function lookup paths used during object-pool related dumping/output.
- Replaced unsafe direct dereferences with explicit fallback text for unknown/unresolved targets.

## Validation

Tested successfully on:
- Dart 3.10.4
- Dart 3.11.1

Both versions now decompile successfully on my side.

## Notes

These changes intentionally prefer graceful fallback over assertion-based termination when the analyzer cannot confidently prove that a newer ARM64 instruction pattern matches an existing semantic path.

The `DartDumper.cpp` changes are limited to null-safety hardening and do not introduce new decoding semantics.