### PR TITLE
fix: IDA 9.0+ compat, Frida 17.0+ compat, bad chars in names, stripped ELF

### DIFF
--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -25,6 +25,14 @@ static std::unordered_map<std::string, std::string> OP_MAP {
 	{ "&", "LAnd" }, { "|", "LOr" }, { "^", "xor" }, { "~", "not" }, {">>", "shar"}, {"<<", "shal"}, {">>", "shr"}
 };
 
+// Replace characters that IDA Pro rejects in symbol names (|, -)
+static std::string sanitizeName4Ida(std::string name) {
+	for (char& c : name) {
+		if (c == '|' || c == '-') c = '_';
+	}
+	return name;
+}
+
 static std::string getFunctionName4Ida(const DartFunction& dartFn, const std::string& cls_prefix)
 {
 	auto fnName = dartFn.Name();
@@ -86,16 +94,19 @@ void DartDumper::Dump4Ida(std::filesystem::path outDir)
 {
 	std::filesystem::create_directory(outDir);
 	std::ofstream of((outDir / "addNames.py").string());
+	of << "# -*- coding: utf-8 -*-\n";
 	of << "import ida_funcs\n";
 	of << "import idaapi\n\n";
 
 	for (auto lib : app.libs) {
-		std::string lib_prefix = lib->GetName();
+		const auto lib_prefix = sanitizeName4Ida(lib->GetName());
 		for (auto cls : lib->classes) {
-			std::string cls_prefix = cls->Name();
+			const std::string raw_cls_prefix = cls->Name();
+			const auto cls_prefix = sanitizeName4Ida(raw_cls_prefix);
 			for (auto dartFn : cls->Functions()) {
 				const auto ep = dartFn->Address();
-				auto name = getFunctionName4Ida(*dartFn, cls_prefix);
+				// pass raw (unsanitized) cls_prefix so constructor prefix matching still works
+				auto name = sanitizeName4Ida(getFunctionName4Ida(*dartFn, raw_cls_prefix));
 				const auto fnSize = dartFn->Size();
 				if (fnSize > 0) {
 					of << std::format("ida_funcs.add_func({:#x}, {:#x})\n", ep, ep + fnSize);
@@ -134,7 +145,11 @@ void DartDumper::Dump4Ida(std::filesystem::path outDir)
 	//   use header file then adding comment is much faster
 	auto comments = DumpStructHeaderFile((outDir / "ida_dart_struct.h").string());
 	of << R"CBLOCK(
-import ida_struct
+try:
+    import ida_struct
+except ImportError:
+    # IDA 9.0+ merged ida_struct into ida_typeinf
+    import ida_typeinf as ida_struct
 import os
 def create_Dart_structs():
 	sid1 = idc.get_struc_id("DartThread")

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -96,7 +96,8 @@ void DartDumper::Dump4Ida(std::filesystem::path outDir)
 	std::ofstream of((outDir / "addNames.py").string());
 	of << "# -*- coding: utf-8 -*-\n";
 	of << "import ida_funcs\n";
-	of << "import idaapi\n\n";
+	of << "import idaapi\n";
+	of << "import idc\n\n";
 
 	for (auto lib : app.libs) {
 		const auto lib_prefix = sanitizeName4Ida(lib->GetName());
@@ -145,11 +146,6 @@ void DartDumper::Dump4Ida(std::filesystem::path outDir)
 	//   use header file then adding comment is much faster
 	auto comments = DumpStructHeaderFile((outDir / "ida_dart_struct.h").string());
 	of << R"CBLOCK(
-try:
-    import ida_struct
-except ImportError:
-    # IDA 9.0+ merged ida_struct into ida_typeinf
-    import ida_typeinf as ida_struct
 import os
 def create_Dart_structs():
 	sid1 = idc.get_struc_id("DartThread")
@@ -159,10 +155,11 @@ def create_Dart_structs():
 	idaapi.idc_parse_types(hdr_file, idc.PT_FILE)
 	sid1 = idc.import_type(-1, "DartThread")
 	sid2 = idc.import_type(-1, "DartObjectPool")
-	struc = ida_struct.get_struc(sid2)
 )CBLOCK";
+	// idc.set_member_cmt(sid, byte_offset, comment, repeatable) is unchanged in IDA 7, 8 and 9.
+	// ida_struct was removed in IDA 9 and ida_typeinf is not a drop-in replacement for it.
 	for (const auto& [offset, comment] : comments) {
-		of << "\tida_struct.set_member_cmt(ida_struct.get_member(struc, " << offset << "), '''" << comment << "''', True)\n";
+		of << "\tidc.set_member_cmt(sid2, " << offset << ", '''" << comment << "''', True)\n";
 	}
 	of << "\treturn sid1, sid2\n";
 	of << "thrs, pps = create_Dart_structs()\n";

--- a/extract_dart_info.py
+++ b/extract_dart_info.py
@@ -19,7 +19,9 @@ def extract_snapshot_hash_flags(libapp_file):
         dynsym = elf.get_section_by_name('.dynsym')
         sym = dynsym.get_symbol_by_name('_kDartVmSnapshotData')[0]
         #section = elf.get_section(sym['st_shndx'])
-        assert sym['st_size'] > 128
+        # st_size may be 0 in stripped ELF files; allow it and attempt to read anyway
+        assert sym['st_size'] == 0 or sym['st_size'] > 128, \
+            f"Unexpected _kDartVmSnapshotData size: {sym['st_size']}"
         f.seek(sym['st_value']+20)
         snapshot_hash = f.read(32).decode()
         data = f.read(256) # should be enough

--- a/scripts/frida.template.js
+++ b/scripts/frida.template.js
@@ -17,19 +17,18 @@ function onLibappLoaded() {
 
 function tryLoadLibapp() {
     try {
-        libapp = Module.findBaseAddress('libapp.so');
+        // Frida >= 17.0.0: Process.getModuleByName throws if module not loaded
+        libapp = Process.getModuleByName('libapp.so').base;
     } catch (e) {
-        if (e instanceof TypeError && e.message === "not a function") {
-            libapp = Process.findModuleByName('libapp.so');
-            if (libapp != null) {
-                libapp = libapp.base;
-            }
-        } else {
-            throw e;
+        try {
+            // Frida < 17.0.0 fallback
+            libapp = Module.findBaseAddress('libapp.so');
+        } catch (e2) {
+            libapp = null;
         }
     }
     if (libapp === null)
-        setTimeout(tryLoadLibapp, 500);    
+        setTimeout(tryLoadLibapp, 500);
     else
         onLibappLoaded();
 }


### PR DESCRIPTION
## Summary

Fixes several compatibility issues reported by users across multiple open issues.

### Changes

**`blutter/src/DartDumper.cpp`**
- Add `# -*- coding: utf-8 -*-` encoding declaration to the generated `addNames.py` — fixes `SyntaxError: Non-ASCII character` in old IDA Python 2 environments (#145)
- Add `sanitizeName4Ida()` helper that replaces `|` (Dart extension separator) and `-` (hyphen in package names) with `_` — eliminates IDA's "bad character" errors in `idaapi.set_name()` (#186)
- Stop emitting `ida_struct` calls. The generated script now emits one `idc.set_member_cmt(sid2, <byte offset>, ...)` per object-pool member, and adds an explicit `import idc` — fixes `ModuleNotFoundError: No module named 'ida_struct'` on IDA 9.0+ (#181, #198)

**`scripts/frida.template.js`**
- Rewrite `tryLoadLibapp()` to try `Process.getModuleByName('libapp.so').base` first (Frida ≥ 17.0.0 API), falling back to `Module.findBaseAddress()` for older Frida — the previous fallback itself called `Process.findModuleByName()` which was also removed in Frida 17.0.0, causing an uncaught `TypeError` (#168)

**`extract_dart_info.py`**
- Accept `st_size == 0` in the `_kDartVmSnapshotData` assertion — some ELF files have symbol size stripped to 0 while the data itself is still readable at the symbol's address; the previous hard assertion caused an unhelpful `AssertionError` crash (#154)

### Why `idc.set_member_cmt` and not an `ida_struct` shim

The first revision of this PR aliased `ida_typeinf` to `ida_struct`. @AK-103U tested it on IDA Pro 9.3 and correctly reported that this only converts `ImportError` into `AttributeError`: `ida_typeinf` exports no `get_struc`, `get_member` or `set_member_cmt` (verified against the IDAPython sources shipped with IDA Pro 9.4 — `grep -c get_struc python/ida_typeinf.py` returns 0).

`idc.set_member_cmt(sid, member_offset, comment, repeatable)` is the portable alternative:

- The signature is unchanged in IDA 7.0, 7.7, 8.4 and 9.x.
- On IDA 7.x/8.x it internally performs `ida_struct.get_struc(sid)` → `ida_struct.get_member(s, member_offset)` → `ida_struct.set_member_cmt(m, comment, repeatable)`, which is exactly the sequence the generator used to emit inline. Behaviour on IDA 8 and earlier is therefore unchanged.
- On IDA 9 it uses `tinfo_t.find_udm(udm, STRMEM_AUTO)` + `tinfo_t.set_udm_cmt`, the mapping the [IDAPython 9 porting guide](https://docs.hex-rays.com/9.0/developer-guide/idapython/idapython-porting-guide-ida-9) recommends for `set_member_cmt`.

`STRMEM_AUTO` performs an exact byte-offset match ("struct: offset is in bytes (not in bits)!"), so it is worth stating why the offsets still resolve. The generator passes `dart::ObjectPool::OffsetFromIndex(i) + 1`, and the Dart SDK defines `OffsetFromIndex(index)` as `element_offset(index) - kHeapObjectTag`. The `+ 1` therefore cancels `kHeapObjectTag`, leaving `element_offset(i)` — a multiple of 8 that lands exactly on a member start in the generated `DartObjectPool` struct.

### Testing status

- The generated Python was checked for syntax validity, and the modified emission code was compiled and run in isolation under C++20.
- **Not verified by execution in IDA.** I have no IDA Pro license available for a real run. @AK-103U, if you still have IDA Pro 9.3 at hand, a re-test would be very welcome.
- One thing I could not settle from the shipped Python sources: `idaapi.idc_parse_types(hdr_file, idc.PT_FILE)` is a native binding, so I cannot confirm from source that parsing a header **file path** still works on IDA 9. `PT_FILE` and `idaapi.idc_parse_types` both still exist in 9.4. In [#198](https://github.com/worawit/blutter/issues/198#issuecomment-5535497297) @ys1231 replaced that call with reading the file and calling `idc_parse_types(<string>, 0)`, which suggests the file-path path may be broken. If `create_Dart_structs()` reports that `DartObjectPool` could not be imported on IDA 9, that is the next thing to fix, and I will add the string fallback.

## Related Issues

Closes / addresses: #145, #154, #168, #181, #186, #198
