### PR TITLE
Support iOS and macOS applications (Mach-O)

### DIFF
--- a/blutter.py
+++ b/blutter.py
@@ -48,18 +48,23 @@ class BlutterInput:
 
 
 def find_lib_files(indir: str):
-    app_file = os.path.join(indir, 'libapp.so')
-    if not os.path.isfile(app_file):
-        app_file = os.path.join(indir, 'App')
-        if not os.path.isfile(app_file):
-            sys.exit("Cannot find libapp file")
-    
-    flutter_file = os.path.join(indir, 'libflutter.so')
-    if not os.path.isfile(flutter_file):
-        flutter_file = os.path.join(indir, 'Flutter')
-        if not os.path.isfile(flutter_file):
-            sys.exit("Cannot find libflutter file")
-    
+    # an iOS application keeps each binary in its own framework directory,
+    # so accept the "Frameworks" directory of the bundle as well
+    def find_one(*candidates):
+        for candidate in candidates:
+            path = os.path.join(indir, candidate)
+            if os.path.isfile(path):
+                return path
+        return None
+
+    app_file = find_one('libapp.so', 'App', os.path.join('App.framework', 'App'))
+    if app_file is None:
+        sys.exit("Cannot find libapp file")
+
+    flutter_file = find_one('libflutter.so', 'Flutter', os.path.join('Flutter.framework', 'Flutter'))
+    if flutter_file is None:
+        sys.exit("Cannot find libflutter file")
+
     return os.path.abspath(app_file), os.path.abspath(flutter_file)
 
 def extract_libs_from_apk(apk_file: str, out_dir: str):

--- a/blutter.py
+++ b/blutter.py
@@ -48,20 +48,33 @@ class BlutterInput:
 
 
 def find_lib_files(indir: str):
-    # an iOS application keeps each binary in its own framework directory,
-    # so accept the "Frameworks" directory of the bundle as well
+    # Android ships bare .so files. iOS and macOS ship frameworks, and differ:
+    # iOS puts the binary at the top of the bundle, macOS under Versions/A with
+    # a symlink at the top, and macOS names the engine framework FlutterMacOS.
+    def framework_paths(name: str):
+        bundle = f'{name}.framework'
+        return (
+            name,
+            os.path.join(bundle, name),
+            os.path.join(bundle, 'Versions', 'A', name),
+            os.path.join(bundle, 'Versions', 'Current', name),
+        )
+
     def find_one(*candidates):
         for candidate in candidates:
             path = os.path.join(indir, candidate)
+            # isfile() follows symlinks, so a bundle's top-level link is fine,
+            # and a *directory* that happens to share the name is skipped
             if os.path.isfile(path):
                 return path
         return None
 
-    app_file = find_one('libapp.so', 'App', os.path.join('App.framework', 'App'))
+    app_file = find_one('libapp.so', *framework_paths('App'))
     if app_file is None:
         sys.exit("Cannot find libapp file")
 
-    flutter_file = find_one('libflutter.so', 'Flutter', os.path.join('Flutter.framework', 'Flutter'))
+    flutter_file = find_one(
+        'libflutter.so', *framework_paths('Flutter'), *framework_paths('FlutterMacOS'))
     if flutter_file is None:
         sys.exit("Cannot find libflutter file")
 

--- a/blutter/sourcelist.cmake
+++ b/blutter/sourcelist.cmake
@@ -32,6 +32,8 @@ set(SRCS
     FridaWriter.cpp
     FridaWriter.h
     HtArrayIterator.h
+    MachOHelper.cpp
+    MachOHelper.h
     Util.cpp
     Util.h
     VarValue.cpp

--- a/blutter/src/CodeAnalyzer_arm64.cpp
+++ b/blutter/src/CodeAnalyzer_arm64.cpp
@@ -183,18 +183,61 @@ static VarValue* getPoolObject(DartApp& app, intptr_t offset, A64::Register dstR
 	}
 }
 
+// A Smi holding a count or an index is scaled to a byte offset differently
+// depending on pointer compression. With compression the Smi is 32 bits, so it
+// sits in a W register and is scaled with "sxtw #n"; without it the Smi fills a
+// whole X register and is scaled with a plain "lsl #n". Where the indexed
+// elements are pointers the scale grows by one as well, because an
+// uncompressed pointer is twice as wide - hence the two shift arguments.
+static inline bool isSmiScaledOperand(const cs_arm64_op& op, arm64_reg reg, int compressedShift, int uncompressedShift)
+{
+	if (ToCapstoneReg(op.reg) != ToCapstoneReg(reg))
+		return false;
+#if defined(DART_COMPRESSED_POINTERS)
+	return op.ext == ARM64_EXT_SXTW && op.shift.value == compressedShift;
+#else
+	// Capstone spells the plain shifted-register form with no extend, but do not
+	// insist on which of the two it reports - only that it is not a sign extend.
+	return op.ext != ARM64_EXT_SXTW && op.shift.value == uncompressedShift;
+#endif
+}
+
+// A Smi is untagged to a native integer differently depending on pointer
+// compression. A compressed Smi occupies 32 bits, so the compiler untags it
+// with "sbfx #kSmiTagSize, #31"; an uncompressed one fills the whole word and
+// is untagged with a plain "asr #kSmiTagSize".
+static inline bool isSmiUntagToNative(AsmIterator& insn)
+{
+	if (insn.id() == ARM64_INS_SBFX)
+		return insn.ops(2).imm == dart::kSmiTagSize && insn.ops(3).imm == 31;
+#if defined(DART_COMPRESSED_POINTERS)
+	// a compressed build never untags with a bare shift, and accepting one here
+	// would match unrelated arithmetic
+	return false;
+#else
+	return insn.id() == ARM64_INS_ASR && insn.ops(2).type == ARM64_OP_IMM && insn.ops(2).imm == dart::kSmiTagSize;
+#endif
+}
+
+// Without pointer compression (as on iOS) a loaded pointer is already a full
+// address, so the compiler emits no decompression at all and there is nothing
+// to consume here.
 static inline void handleDecompressPointer(AsmIterator& insn, arm64_reg reg) {
+#if defined(DART_COMPRESSED_POINTERS)
 	INSN_ASSERT(insn.id() == ARM64_INS_ADD);
 	INSN_ASSERT(insn.ops(0).reg == insn.ops(1).reg && insn.ops(0).reg == reg);
 	INSN_ASSERT(insn.ops(2).reg == CSREG_DART_HEAP && insn.ops(2).shift.value == 32);
 	++insn;
+#endif
 }
 
 static inline void handleExtraDecompressPointer(AsmIterator& insn, arm64_reg reg) {
+#if defined(DART_COMPRESSED_POINTERS)
 	if (insn.id() != ARM64_INS_ADD) return;
 	if (!(insn.ops(0).reg == insn.ops(1).reg && insn.ops(0).reg == reg)) return;
 	if (!(insn.ops(2).reg == CSREG_DART_HEAP && insn.ops(2).shift.value == 32)) return;
 	++insn;
+#endif
 }
 
 // Handle leave-frame restore patterns for newer Dart ARM64 codegen.
@@ -923,7 +966,7 @@ void FunctionAnalyzer::handleFixedParameters(AsmIterator& insn, arm64_reg paramC
 			break;
 		INSN_ASSERT(insn.ops(1).reg == CSREG_DART_FP);
 		// shift only 2 because the number of parameter is Smi (tagged)
-		INSN_ASSERT(ToCapstoneReg(insn.ops(2).reg) == paramCntReg && insn.ops(2).ext == ARM64_EXT_SXTW && insn.ops(2).shift.value == 2);
+		INSN_ASSERT(isSmiScaledOperand(insn.ops(2), paramCntReg, 2, 2));
 		const auto tmpReg = insn.ops(0).reg;
 		++insn;
 
@@ -995,7 +1038,7 @@ void FunctionAnalyzer::handleOptionalPositionalParameters(AsmIterator& insn, arm
 		// parameter might not be used and no loading value
 		if (insn.id() == ARM64_INS_ADD && insn.ops(1).reg == CSREG_DART_FP) {
 			// shift only 2 because the number of parameter is Smi (tagged)
-			INSN_ASSERT(ToCapstoneReg(insn.ops(2).reg) == optionalParamCntReg && insn.ops(2).ext == ARM64_EXT_SXTW && insn.ops(2).shift.value == 2);
+			INSN_ASSERT(isSmiScaledOperand(insn.ops(2), optionalParamCntReg, 2, 2));
 			const auto tmpReg = insn.ops(0).reg;
 			++insn;
 
@@ -1137,12 +1180,17 @@ void FunctionAnalyzer::handleOptionalNamedParameters(AsmIterator& insn, arm64_re
 
 				INSN_ASSERT(insn.id() == ARM64_INS_ADD);
 				INSN_ASSERT(fnInfo->State()->GetValue(insn.ops(1).reg) == fnInfo->Vars()->ValArgsDesc());
-				INSN_ASSERT(insn.ops(2).reg == tmpReg && insn.ops(2).ext == ARM64_EXT_SXTW && insn.ops(2).shift.value == 1);
+				// the argument descriptor is an array of pointers, so an
+				// uncompressed build scales the Smi index one bit further
+				INSN_ASSERT(isSmiScaledOperand(insn.ops(2), tmpReg, 1, 2));
 				const auto tmpReg2 = insn.ops(0).reg;
 				++insn;
 
 				INSN_ASSERT(insn.id() == ARM64_INS_LDUR);
-				INSN_ASSERT(insn.ops(1).mem.base == tmpReg2 && insn.ops(1).mem.disp == sizeof(void*) * 2 - dart::kHeapObjectTag);
+				// the argument descriptor is an Array, whose header holds two
+				// compressed fields - so its data offset is not "2 pointers"
+				// unless pointers happen to be compressed
+				INSN_ASSERT(insn.ops(1).mem.base == tmpReg2 && insn.ops(1).mem.disp == dart::Array::data_offset() - dart::kHeapObjectTag);
 				const auto dstReg = ToCapstoneReg(insn.ops(0).reg);
 				++insn;
 
@@ -1340,7 +1388,7 @@ void FunctionAnalyzer::handleOptionalNamedParameters(AsmIterator& insn, arm64_re
 
 			INSN_ASSERT(insn.id() == ARM64_INS_ADD);
 			INSN_ASSERT(insn.ops(1).reg == CSREG_DART_FP);
-			INSN_ASSERT(insn.ops(2).reg == tmpReg && insn.ops(2).ext == ARM64_EXT_SXTW && insn.ops(2).shift.value == 2);
+			INSN_ASSERT(isSmiScaledOperand(insn.ops(2), tmpReg, 2, 2));
 			const auto tmpReg2 = insn.ops(0).reg;
 			++insn;
 
@@ -1393,10 +1441,9 @@ void FunctionAnalyzer::handleOptionalNamedParameters(AsmIterator& insn, arm64_re
 		if (!isRequired) {
 			// Smi to native. only non first and last name do it
 			if (nameParamCnt && !isLastName) {
-				// 0x412924: sbfx  x5, x2, #1, #0x1f
-				if (insn.id() == ARM64_INS_SBFX) {
+				// 0x412924: sbfx  x5, x2, #1, #0x1f  (or "asr x5, x2, #1")
+				if (isSmiUntagToNative(insn)) {
 					INSN_ASSERT(fnInfo->State()->GetValue(insn.ops(1).reg) == &valNameCurrParamPosSmi);
-					INSN_ASSERT(insn.ops(2).imm == 1 && insn.ops(3).imm == 0x1f);
 					fnInfo->State()->SetRegister(insn.ops(0).reg, fnInfo->Vars()->ValCurrNumNameParam());
 					++insn;
 				}
@@ -1444,7 +1491,7 @@ void FunctionAnalyzer::handleOptionalNamedParameters(AsmIterator& insn, arm64_re
 			}
 
 			// TODO: split state for match and mismatch branch, so all param can be tracked correctly
-			if (insn.id() == ARM64_INS_SBFX && insn.ops(2).imm == 1 && insn.ops(3).imm == 0x1f) {
+			if (isSmiUntagToNative(insn)) {
 				// assume curr param pos Smi to native in default branch
 				++insn;
 			}
@@ -1584,7 +1631,7 @@ void FunctionAnalyzer::handleArgumentsDescriptorTypeArguments(AsmIterator& insn)
 
 	INSN_ASSERT(insn.id() == ARM64_INS_ADD);
 	INSN_ASSERT(insn.ops(1).reg == CSREG_DART_FP);
-	INSN_ASSERT(ToCapstoneReg(insn.ops(2).reg) == sizeReg && insn.ops(2).ext == ARM64_EXT_SXTW && insn.ops(2).shift.value == 2);
+	INSN_ASSERT(isSmiScaledOperand(insn.ops(2), sizeReg, 2, 2));
 	const auto tmpReg = insn.ops(0).reg;
 	fnInfo->State()->ClearRegister(tmpReg);
 	++insn;
@@ -2947,7 +2994,7 @@ std::unique_ptr<LoadInt32Instr> FunctionAnalyzer::processLoadInt32FromBoxOrSmiIn
 {
 	// From UnboxInstr::EmitLoadInt32FromBoxOrSmi(), includes branch if Smi
 	//   output is raw integer, input is Dart object
-	if (insn.id() == ARM64_INS_SBFX && insn.ops(2).imm == dart::kSmiTagSize && insn.ops(3).imm == 31) {
+	if (isSmiUntagToNative(insn)) {
 		const auto in_reg = insn.ops(1).reg;
 		const auto srcReg = A64::Register{ in_reg };
 		if (!expectedSrcReg.IsSet() || expectedSrcReg == srcReg) {
@@ -3022,7 +3069,11 @@ std::unique_ptr<ILInstr> FunctionAnalyzer::processLoadFieldTableInstr(AsmIterato
 
 		INSN_ASSERT(insn.ops(1).mem.base == tmp_reg);
 		load_offset |= insn.ops(1).mem.disp;
-		const auto field_offset = load_offset >> 1;
+		// The field table is a plain array of ObjectPtr, so the compiler emits
+		// a displacement of field_id * kWordSize, while Field::Offset() (which
+		// is Field::HostOffset()) reports field_id * kCompressedWordSize. The
+		// two differ by a factor of two only when pointers are compressed.
+		const auto field_offset = load_offset / (dart::kWordSize / dart::kCompressedWordSize);
 
 		if (insn.id() == ARM64_INS_STR) {
 			const auto reg = A64::Register{ insn.ops(0).reg };
@@ -3525,7 +3576,12 @@ std::unique_ptr<ILInstr> FunctionAnalyzer::processLoadStore(AsmIterator& insn)
 				INSN_ASSERT(shift.value == idxShiftVal);
 			}
 			bool isTypedData = dart::UntaggedTypedData::payload_offset() - dart::kHeapObjectTag == arr_data_offset;
-			INSN_ASSERT(isTypedData || arr_data_offset == dart::Array::data_offset() - dart::kHeapObjectTag);
+			// Reading a character out of a String is the same shape of access,
+			// but its payload starts right after the header and length rather
+			// than at the TypedData payload.
+			const bool isStringData = arr_data_offset == dart::OneByteString::data_offset() - dart::kHeapObjectTag
+				|| arr_data_offset == dart::TwoByteString::data_offset() - dart::kHeapObjectTag;
+			INSN_ASSERT(isTypedData || isStringData || arr_data_offset == dart::Array::data_offset() - dart::kHeapObjectTag);
 			const auto op0Reg = A64::Register{ insn.ops(0).reg };
 			++insn;
 			if (arrayOp.isLoad) {

--- a/blutter/src/DartApp.cpp
+++ b/blutter/src/DartApp.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "DartApp.h"
 #include "ElfHelper.h"
+#include "MachOHelper.h"
 #include "DartLoader.h"
 PRAGMA_WARNING(push, 0)
 #include <vm/stub_code.h>
@@ -11,7 +12,8 @@ PRAGMA_WARNING(pop)
 
 DartApp::DartApp(const char* path) : ppool(NULL), nativeLib(0xdeadead), throwStubAddr(0)
 {
-	auto libInfo = ElfHelper::MapLibAppSo(path);
+	// An Android app ships libapp.so, an iOS/macOS one App.framework/App.
+	auto libInfo = MachOHelper::IsMachO(path) ? MachOHelper::MapLibApp(path) : ElfHelper::MapLibAppSo(path);
 	lib_base = libInfo.lib;
 	vm_snapshot_data = libInfo.vm_snapshot_data;
 	vm_snapshot_instructions = libInfo.vm_snapshot_instructions;

--- a/blutter/src/DartClass.cpp
+++ b/blutter/src/DartClass.cpp
@@ -43,12 +43,16 @@ DartClass::DartClass(const DartLibrary& lib_, const dart::Class& cls) :
 	if (!dart::ClassTable::IsTopLevelCid(id)) {
 		//auto& supCls = dart::Class::Handle(zone, cls.SuperClass());
 		auto supClsPtr = cls.SuperClass();
-		
-		auto superCid = supClsPtr.untag()->id();
-		if (superCid > 0 && (intptr_t)supClsPtr == (intptr_t)dart::Object::null())
-			superCid = 0;
-		if (superCid)
-			superCls = (DartClass*)(intptr_t)superCid; // temporary save class id as pointer. it will be set correctly after all classes are loaded
+
+		// Object has no super class. Test the pointer before reading a class id
+		// out of it: the id of the null object is meaningless, and without
+		// pointer compression it reads back negative, which the previous
+		// "superCid > 0" test let through as a bogus class id.
+		if (supClsPtr != dart::Class::null()) {
+			const auto superCid = supClsPtr.untag()->id();
+			if (superCid)
+				superCls = (DartClass*)(intptr_t)superCid; // temporary save class id as pointer. it will be set correctly after all classes are loaded
+		}
 
 		if (cls.is_const())
 			is_const_constructor = true;

--- a/blutter/src/Disassembler_arm64.h
+++ b/blutter/src/Disassembler_arm64.h
@@ -81,9 +81,12 @@ constexpr arm64_reg CSREG_DART_WB_VALUE = ToCapstoneReg(dart::kWriteBarrierValue
 constexpr arm64_reg CSREG_DART_WB_SLOT = ToCapstoneReg(dart::kWriteBarrierSlotReg);
 constexpr arm64_reg CSREG_DART_THR = ToCapstoneReg(dart::THR);
 constexpr arm64_reg CSREG_DART_PP = ToCapstoneReg(dart::PP);
-#if defined(DART_COMPRESSED_POINTERS)
+// HEAP_BITS is "write_barrier_mask << 32 | heap_base >> 32", so the write
+// barrier reads it even when pointers are not compressed (as on iOS). The
+// pointer decompression patterns simply never show up in such a build.
+// Note: this used to be guarded by DART_COMPRESSED_POINTERS, but the guard was
+// unusable - CodeAnalyzer_arm64.cpp refers to the register unconditionally.
 constexpr arm64_reg CSREG_DART_HEAP = ToCapstoneReg(dart::HEAP_BITS);
-#endif
 constexpr arm64_reg CSREG_DART_TMP = ToCapstoneReg(dart::TMP);
 constexpr arm64_reg CSREG_DART_TMP2 = ToCapstoneReg(dart::TMP2);
 // Note: kTagReg is normally in wrapper function. can ignore it.

--- a/blutter/src/ElfHelper.cpp
+++ b/blutter/src/ElfHelper.cpp
@@ -2,10 +2,6 @@
 #include "ElfHelper.h"
 PRAGMA_WARNING(push, 0)
 #include <platform/elf.h>
-#if defined(DART_TARGET_OS_MACOS)
-// old dart version has no mach_o.h
-//#include <platform/mach_o.h>
-#endif
 PRAGMA_WARNING(pop)
 #include <algorithm>
 #include <stdexcept>
@@ -152,24 +148,6 @@ LibAppInfo ElfHelper::MapLibAppSo(const char* path)
 	void* lib = load_map_file(path);
 	// quick and dirty parsing ELF to get symbol addresses
 	uint8_t* elf = (uint8_t*)(lib);
-#if defined(DART_TARGET_OS_MACOS)
-	// Note: only new dart version getting snapshots from load command
-	// <=2.17, use EXPORT name
-	// <= v2.18,  load from sub SEGMENT_64, named "__CUSTOM" and section named "__dart_app_snap"
-	// >= 2.19, LC_NOTE command is used
-	auto header = (dart::mach_o::mach_header_64*)lib;
-	switch (header->magic) {
-	case dart::mach_o::MH_MAGIC:
-	case dart::mach_o::MH_CIGAM:
-		throw std::invalid_argument("Mach-O: Support only 64 bits");
-	case dart::mach_o::MH_CIGAM_64:
-		throw std::invalid_argument("Mach-O: Expected a host endian header");
-	case dart::mach_o::MH_MAGIC_64:
-		return size >= sizeof(mach_o::mach_header_64);
-	default:
-		throw std::invalid_argument("Mach-O: Invalid magic header");
-	}
-#else
 	const auto* hdr = (ElfHeader*)elf;
 	const auto* ident = (ElfIdent*)hdr->ident;
 	if (memcmp(ident->ei_magic, "\x7f" "ELF", 4) != 0)
@@ -185,7 +163,6 @@ LibAppInfo ElfHelper::MapLibAppSo(const char* path)
 	//   0x3e: x86-64, 0xB7: Aarch64
 	// EM_386, EM_ARM, EM_X86_64, EM_AARCH64
 	//hdr->e_machine;
-#endif
 
 	return findSnapshots(elf);
 }

--- a/blutter/src/MachOHelper.cpp
+++ b/blutter/src/MachOHelper.cpp
@@ -1,0 +1,309 @@
+#include "pch.h"
+#include "MachOHelper.h"
+#include <cstdio>
+#include <cstring>
+#include <new>
+#include <stdexcept>
+
+// The Mach-O structures are declared here rather than taken from
+// <platform/mach_o.h> because that header only exists in recent Dart SDKs,
+// while this file is compiled against every Dart version Blutter supports.
+namespace {
+
+constexpr uint32_t MH_MAGIC = 0xfeedface;
+constexpr uint32_t MH_CIGAM = 0xcefaedfe;
+constexpr uint32_t MH_MAGIC_64 = 0xfeedfacf;
+constexpr uint32_t MH_CIGAM_64 = 0xcffaedfe;
+// A fat (universal) header is always stored big endian.
+constexpr uint32_t FAT_MAGIC = 0xcafebabe;
+constexpr uint32_t FAT_CIGAM = 0xbebafeca;
+
+constexpr uint32_t LC_SYMTAB = 0x02;
+constexpr uint32_t LC_SEGMENT_64 = 0x19;
+
+// n_type is a symbolic debugging entry when any N_STAB bit is set, otherwise
+// the N_TYPE bits say where the symbol lives.
+constexpr uint8_t N_STAB = 0xe0;
+constexpr uint8_t N_TYPE = 0x0e;
+constexpr uint8_t N_SECT = 0x0e;
+
+constexpr int32_t CPU_TYPE_X86_64 = 0x01000007;
+constexpr int32_t CPU_TYPE_ARM64 = 0x0100000c;
+
+#pragma pack(push, 1)
+struct mach_header_64 {
+	uint32_t magic;
+	int32_t cputype;
+	int32_t cpusubtype;
+	uint32_t filetype;
+	uint32_t ncmds;
+	uint32_t sizeofcmds;
+	uint32_t flags;
+	uint32_t reserved;
+};
+
+struct load_command {
+	uint32_t cmd;
+	uint32_t cmdsize;
+};
+
+struct segment_command_64 {
+	uint32_t cmd;
+	uint32_t cmdsize;
+	char segname[16];
+	uint64_t vmaddr;
+	uint64_t vmsize;
+	uint64_t fileoff;
+	uint64_t filesize;
+	int32_t maxprot;
+	int32_t initprot;
+	uint32_t nsects;
+	uint32_t flags;
+};
+
+struct symtab_command {
+	uint32_t cmd;
+	uint32_t cmdsize;
+	uint32_t symoff;
+	uint32_t nsyms;
+	uint32_t stroff;
+	uint32_t strsize;
+};
+
+struct nlist_64 {
+	uint32_t n_strx;
+	uint8_t n_type;
+	uint8_t n_sect;
+	uint16_t n_desc;
+	uint64_t n_value;
+};
+
+struct fat_header {
+	uint32_t magic;
+	uint32_t nfat_arch;
+};
+
+struct fat_arch {
+	int32_t cputype;
+	int32_t cpusubtype;
+	uint32_t offset;
+	uint32_t size;
+	uint32_t align;
+};
+#pragma pack(pop)
+
+// Segments are page aligned relative to the image base, so keeping the base
+// itself page aligned preserves the alignment the Dart VM expects of the
+// instructions image.
+constexpr size_t kImageAlignment = 0x10000;
+
+uint32_t bswap32(uint32_t value)
+{
+	return ((value & 0xff000000) >> 24) | ((value & 0x00ff0000) >> 8) |
+		((value & 0x0000ff00) << 8) | ((value & 0x000000ff) << 24);
+}
+
+std::vector<uint8_t> read_whole_file(const char* path)
+{
+	FILE* fp = fopen(path, "rb");
+	if (fp == nullptr)
+		throw std::invalid_argument(std::string("Mach-O: Cannot open ") + path);
+
+	fseek(fp, 0, SEEK_END);
+	const auto size = ftell(fp);
+	if (size <= 0) {
+		fclose(fp);
+		throw std::invalid_argument(std::string("Mach-O: Cannot read ") + path);
+	}
+	fseek(fp, 0, SEEK_SET);
+
+	std::vector<uint8_t> buffer(static_cast<size_t>(size));
+	const auto nread = fread(buffer.data(), 1, buffer.size(), fp);
+	fclose(fp);
+	if (nread != buffer.size())
+		throw std::invalid_argument(std::string("Mach-O: Truncated read of ") + path);
+
+	return buffer;
+}
+
+// Reads little endian values out of the file with a bounds check, so a
+// malformed image cannot walk us off the end of the buffer.
+template <typename T>
+const T* at(const std::vector<uint8_t>& file, uint64_t offset, uint64_t count = 1)
+{
+	if (offset > file.size() || count > (file.size() - offset) / sizeof(T))
+		throw std::invalid_argument("Mach-O: Structure outside of the file");
+	return reinterpret_cast<const T*>(file.data() + offset);
+}
+
+// A universal binary holds several images. Pick the one we can analyze,
+// preferring arm64 because that is what Flutter ships for devices.
+uint64_t find_slice(const std::vector<uint8_t>& file)
+{
+	const auto magic = *at<uint32_t>(file, 0);
+	if (magic != FAT_MAGIC && magic != FAT_CIGAM)
+		return 0;
+
+	const auto* header = at<fat_header>(file, 0);
+	const auto count = bswap32(header->nfat_arch);
+	const auto* arches = at<fat_arch>(file, sizeof(fat_header), count);
+
+	uint64_t fallback = 0;
+	for (uint32_t i = 0; i < count; i++) {
+		const auto cputype = static_cast<int32_t>(bswap32(static_cast<uint32_t>(arches[i].cputype)));
+		const uint64_t offset = bswap32(arches[i].offset);
+		if (cputype == CPU_TYPE_ARM64)
+			return offset;
+		if (cputype == CPU_TYPE_X86_64 && fallback == 0)
+			fallback = offset;
+	}
+
+	if (fallback == 0)
+		throw std::invalid_argument("Mach-O: No arm64 or x64 image in the universal binary");
+	return fallback;
+}
+
+struct Segment {
+	uint64_t vmaddr;
+	uint64_t vmsize;
+	uint64_t fileoff;
+	uint64_t filesize;
+};
+
+} // namespace
+
+bool MachOHelper::IsMachO(const char* path)
+{
+	FILE* fp = fopen(path, "rb");
+	if (fp == nullptr)
+		return false;
+
+	uint32_t magic = 0;
+	const auto nread = fread(&magic, 1, sizeof(magic), fp);
+	fclose(fp);
+	if (nread != sizeof(magic))
+		return false;
+
+	// Report the unsupported flavours too, so MapLibApp can explain why.
+	return magic == MH_MAGIC_64 || magic == MH_CIGAM_64 || magic == MH_MAGIC ||
+		magic == MH_CIGAM || magic == FAT_MAGIC || magic == FAT_CIGAM;
+}
+
+LibAppInfo MachOHelper::MapLibApp(const char* path)
+{
+	const auto file = read_whole_file(path);
+	const auto slice = find_slice(file);
+
+	const auto* header = at<mach_header_64>(file, slice);
+	switch (header->magic) {
+	case MH_MAGIC_64:
+		break;
+	case MH_CIGAM_64:
+		throw std::invalid_argument("Mach-O: Expected a host endian header");
+	case MH_MAGIC:
+	case MH_CIGAM:
+		throw std::invalid_argument("Mach-O: Support only 64 bits");
+	default:
+		throw std::invalid_argument("Mach-O: Invalid magic header");
+	}
+
+	// Collect the segments to lay out, and the symbol table to look up.
+	std::vector<Segment> segments;
+	const symtab_command* symtab = nullptr;
+	uint64_t vm_start = UINT64_MAX;
+	uint64_t vm_end = 0;
+
+	uint64_t cmd_offset = slice + sizeof(mach_header_64);
+	for (uint32_t i = 0; i < header->ncmds; i++) {
+		const auto* cmd = at<load_command>(file, cmd_offset);
+		if (cmd->cmdsize < sizeof(load_command))
+			throw std::invalid_argument("Mach-O: Invalid load command size");
+
+		if (cmd->cmd == LC_SEGMENT_64) {
+			const auto* seg = at<segment_command_64>(file, cmd_offset);
+			// __PAGEZERO is an unmapped guard region of several GB.
+			if (seg->vmsize != 0 && strncmp(seg->segname, "__PAGEZERO", sizeof(seg->segname)) != 0) {
+				// Validate the file range now; the contents are copied below.
+				at<uint8_t>(file, slice + seg->fileoff, seg->filesize);
+				segments.push_back(Segment{ seg->vmaddr, seg->vmsize, seg->fileoff, seg->filesize });
+				vm_start = std::min(vm_start, seg->vmaddr);
+				vm_end = std::max(vm_end, seg->vmaddr + seg->vmsize);
+			}
+		}
+		else if (cmd->cmd == LC_SYMTAB) {
+			symtab = at<symtab_command>(file, cmd_offset);
+		}
+
+		cmd_offset += cmd->cmdsize;
+	}
+
+	if (segments.empty())
+		throw std::invalid_argument("Mach-O: No loadable segment");
+	if (symtab == nullptr)
+		throw std::invalid_argument("Mach-O: Cannot find the symbol table");
+
+	// Lay the segments out at their virtual addresses instead of mapping the
+	// file as-is. Unlike an ELF libapp.so, an App binary has a zero filled
+	// __DATA segment whose addresses would otherwise collide with __LINKEDIT,
+	// and the Dart VM writes into that BSS while loading the snapshot.
+	const auto image_size = vm_end - vm_start;
+	auto* image = static_cast<uint8_t*>(::operator new(image_size, std::align_val_t{ kImageAlignment }));
+	memset(image, 0, image_size);
+	for (const auto& seg : segments) {
+		if (seg.filesize != 0)
+			memcpy(image + (seg.vmaddr - vm_start), file.data() + slice + seg.fileoff, seg.filesize);
+	}
+
+	// Find the snapshots. Mach-O keeps them in the regular symbol table, and
+	// under the same names the ELF loader looks for.
+	const uint8_t* vm_snapshot_data = nullptr;
+	const uint8_t* vm_snapshot_instructions = nullptr;
+	const uint8_t* isolate_snapshot_data = nullptr;
+	const uint8_t* isolate_snapshot_instructions = nullptr;
+
+	const auto* symbols = at<nlist_64>(file, slice + symtab->symoff, symtab->nsyms);
+	const auto* strtab = at<char>(file, slice + symtab->stroff, symtab->strsize);
+	for (uint32_t i = 0; i < symtab->nsyms; i++) {
+		const auto& sym = symbols[i];
+		if ((sym.n_type & N_STAB) != 0 || (sym.n_type & N_TYPE) != N_SECT)
+			continue;
+		if (sym.n_strx >= symtab->strsize)
+			continue;
+		if (sym.n_value < vm_start || sym.n_value >= vm_end)
+			continue;
+
+		const char* name = strtab + sym.n_strx;
+		const uint8_t* addr = image + (sym.n_value - vm_start);
+		if (strcmp(name, kVmSnapshotDataAsmSymbol) == 0) {
+			vm_snapshot_data = addr;
+		}
+		else if (strcmp(name, kVmSnapshotInstructionsAsmSymbol) == 0) {
+			vm_snapshot_instructions = addr;
+		}
+		else if (strcmp(name, kIsolateSnapshotDataAsmSymbol) == 0) {
+			isolate_snapshot_data = addr;
+		}
+		else if (strcmp(name, kIsolateSnapshotInstructionsAsmSymbol) == 0) {
+			isolate_snapshot_instructions = addr;
+		}
+	}
+
+	if (vm_snapshot_data == nullptr)
+		throw std::invalid_argument("Mach-O: Cannot find Dart VM Snapshot Data");
+	if (vm_snapshot_instructions == nullptr)
+		throw std::invalid_argument("Mach-O: Cannot find Dart VM Snapshot Instructions");
+	if (isolate_snapshot_data == nullptr)
+		throw std::invalid_argument("Mach-O: Cannot find Dart Isolate Snapshot Data");
+	if (isolate_snapshot_instructions == nullptr)
+		throw std::invalid_argument("Mach-O: Cannot find Dart Isolate Snapshot Instructions");
+
+	// Note: the image is intentionally never freed. It stays alive for the
+	// lifetime of the process, exactly like the ELF file mapping does.
+	return LibAppInfo{
+		.lib = image,
+		.vm_snapshot_data = vm_snapshot_data,
+		.vm_snapshot_instructions = vm_snapshot_instructions,
+		.isolate_snapshot_data = isolate_snapshot_data,
+		.isolate_snapshot_instructions = isolate_snapshot_instructions,
+	};
+}

--- a/blutter/src/MachOHelper.cpp
+++ b/blutter/src/MachOHelper.cpp
@@ -17,6 +17,10 @@ constexpr uint32_t MH_CIGAM_64 = 0xcffaedfe;
 // A fat (universal) header is always stored big endian.
 constexpr uint32_t FAT_MAGIC = 0xcafebabe;
 constexpr uint32_t FAT_CIGAM = 0xbebafeca;
+// fat_arch_64 entries are 32 bytes rather than 20, so a 64-bit fat header
+// parsed as a 32-bit one yields silently wrong slice offsets.
+constexpr uint32_t FAT_MAGIC_64 = 0xcafebabf;
+constexpr uint32_t FAT_CIGAM_64 = 0xbfbafeca;
 
 constexpr uint32_t LC_SYMTAB = 0x02;
 constexpr uint32_t LC_SEGMENT_64 = 0x19;
@@ -141,6 +145,8 @@ const T* at(const std::vector<uint8_t>& file, uint64_t offset, uint64_t count = 
 uint64_t find_slice(const std::vector<uint8_t>& file)
 {
 	const auto magic = *at<uint32_t>(file, 0);
+	if (magic == FAT_MAGIC_64 || magic == FAT_CIGAM_64)
+		throw std::invalid_argument("Mach-O: universal binary with a 64-bit fat header (FAT_MAGIC_64) is not supported");
 	if (magic != FAT_MAGIC && magic != FAT_CIGAM)
 		return 0;
 
@@ -186,7 +192,8 @@ bool MachOHelper::IsMachO(const char* path)
 
 	// Report the unsupported flavours too, so MapLibApp can explain why.
 	return magic == MH_MAGIC_64 || magic == MH_CIGAM_64 || magic == MH_MAGIC ||
-		magic == MH_CIGAM || magic == FAT_MAGIC || magic == FAT_CIGAM;
+		magic == MH_CIGAM || magic == FAT_MAGIC || magic == FAT_CIGAM ||
+		magic == FAT_MAGIC_64 || magic == FAT_CIGAM_64;
 }
 
 LibAppInfo MachOHelper::MapLibApp(const char* path)

--- a/blutter/src/MachOHelper.h
+++ b/blutter/src/MachOHelper.h
@@ -1,0 +1,16 @@
+#pragma once
+// LibAppInfo is shared with the ELF loader.
+#include "ElfHelper.h"
+
+// Finds the Dart AOT snapshots in a Mach-O image, i.e. the "App" binary inside
+// the App.framework of an iOS/macOS Flutter application.
+class MachOHelper final
+{
+public:
+	// Cheap magic check, so a caller can pick between this and ElfHelper.
+	static bool IsMachO(const char* path);
+	static LibAppInfo MapLibApp(const char* path);
+
+private:
+	MachOHelper() = delete;
+};

--- a/dartvm_fetch_build.py
+++ b/dartvm_fetch_build.py
@@ -41,7 +41,9 @@ class DartLibInfo:
         if has_compressed_ptrs is None:
             # use same as flutter default configuration
             # TODO: old Dart version has no pointer compression
-            self.has_compressed_ptrs = os_name != 'ios'
+            # Both Apple targets ship uncompressed; only the iOS case was
+            # covered here before macOS was analyzable.
+            self.has_compressed_ptrs = os_name not in ('ios', 'macos')
         else:
             self.has_compressed_ptrs = has_compressed_ptrs
         self.lib_name = f'dartvm{version}_{os_name}_{arch}'

--- a/extract_dart_info.py
+++ b/extract_dart_info.py
@@ -41,6 +41,7 @@ class MachO:
         with open(path, 'rb') as f:
             self.data = f.read()
 
+        self.slice_size = None  # set by _find_slice for a universal binary
         self.slice_off = self._find_slice()
         magic = self.data[self.slice_off:self.slice_off + 4]
         assert magic == MH_MAGIC_64, f'Unsupported Mach-O image: {magic.hex()}'
@@ -58,6 +59,17 @@ class MachO:
                 self.symtab = unpack('<IIII', self._read(off + 8, 16))
             off += cmdsize
 
+    def slice_data(self):
+        """Just the selected slice.
+
+        Every slice of a universal binary carries its own copy of strings like
+        the engine version, so searching self.data finds whichever slice comes
+        first rather than the one being analyzed.
+        """
+        if self.slice_size is None:
+            return self.data[self.slice_off:]
+        return self.data[self.slice_off:self.slice_off + self.slice_size]
+
     def _find_slice(self):
         # A 64-bit fat header uses 32-byte entries rather than 20, so parsing it
         # as a 32-bit one silently yields nonsense offsets. Say so instead.
@@ -69,13 +81,15 @@ class MachO:
         count = unpack('>I', self.data[4:8])[0]
         fallback = None
         for i in range(count):
-            cputype, _, offset, _, _ = unpack('>iIIII', self.data[8 + i * 20:28 + i * 20])
+            cputype, _, offset, size, _ = unpack('>iIIII', self.data[8 + i * 20:28 + i * 20])
             if cputype == CPU_TYPE_ARM64:
+                self.slice_size = size
                 return offset
             if cputype == CPU_TYPE_X86_64 and fallback is None:
-                fallback = offset
+                fallback = (offset, size)
         assert fallback is not None, 'No arm64 or x64 image in the universal binary'
-        return fallback
+        self.slice_size = fallback[1]
+        return fallback[0]
 
     def _read(self, offset, size):
         start = self.slice_off + offset
@@ -117,7 +131,7 @@ def extract_flutter_framework_info(flutter_file):
     # The engine embeds the Dart VM version string, which names the target
     # directly, e.g. '3.10.7 (stable) (Tue Dec 23 ...) on "ios_arm64"'.
     macho = MachO(flutter_file)
-    m = re.search(br'([\d][\w\.\-]*) \((?:stable|beta|dev)\) \([^)]*\) on "(ios|macos)_(arm64|x64)"', macho.data)
+    m = re.search(br'([\d][\w\.\-]*) \((?:stable|beta|dev)\) \([^)]*\) on "(ios|macos)_(arm64|x64)"', macho.slice_data())
     assert m is not None, 'Cannot find the Dart version in the Flutter framework'
     dart_version = m.group(1).decode()
     os_name = m.group(2).decode()

--- a/extract_dart_info.py
+++ b/extract_dart_info.py
@@ -18,6 +18,9 @@ FAT_MAGIC_64 = b'\xca\xfe\xba\xbf'  # fat_arch_64 entries, not supported
 FAT_CIGAM_64 = b'\xbf\xba\xfe\xca'
 LC_SYMTAB = 0x2
 LC_SEGMENT_64 = 0x19
+LC_BUILD_VERSION = 0x32
+# what a Mach-O calls the platforms Blutter can analyze
+MACHO_PLATFORMS = {1: 'macos', 2: 'ios'}
 N_STAB = 0xe0
 N_TYPE = 0x0e
 N_SECT = 0x0e
@@ -46,9 +49,10 @@ class MachO:
         magic = self.data[self.slice_off:self.slice_off + 4]
         assert magic == MH_MAGIC_64, f'Unsupported Mach-O image: {magic.hex()}'
 
-        _, _, _, _, ncmds, _, _, _ = unpack('<IiiIIIII', self._read(0, 32))
+        _, self.cputype, _, _, ncmds, _, _, _ = unpack('<IiiIIIII', self._read(0, 32))
         self.segments = []  # (vmaddr, vmsize, fileoff, filesize)
         self.symtab = None  # (symoff, nsyms, stroff, strsize)
+        self.platform = None  # from LC_BUILD_VERSION, absent in older images
         off = 32
         for _ in range(ncmds):
             cmd, cmdsize = unpack('<II', self._read(off, 8))
@@ -57,7 +61,22 @@ class MachO:
                 self.segments.append((vmaddr, vmsize, fileoff, filesize))
             elif cmd == LC_SYMTAB:
                 self.symtab = unpack('<IIII', self._read(off + 8, 16))
+            elif cmd == LC_BUILD_VERSION:
+                self.platform = unpack('<I', self._read(off + 8, 4))[0]
             off += cmdsize
+
+    def arch(self):
+        """The architecture of the image itself, which cannot go missing the
+        way an embedded version string can."""
+        if self.cputype == CPU_TYPE_ARM64:
+            return 'arm64'
+        if self.cputype == CPU_TYPE_X86_64:
+            return 'x64'
+        return None
+
+    def os_name(self):
+        """The target named by LC_BUILD_VERSION, if the image carries one."""
+        return MACHO_PLATFORMS.get(self.platform)
 
     def slice_data(self):
         """Just the selected slice.
@@ -128,16 +147,36 @@ def extract_snapshot_hash_flags_macho(app_file):
 
 
 def extract_flutter_framework_info(flutter_file):
-    # The engine embeds the Dart VM version string, which names the target
-    # directly, e.g. '3.10.7 (stable) (Tue Dec 23 ...) on "ios_arm64"'.
+    """Dart version, engine ids and target, from a Mach-O Flutter engine.
+
+    The version string names the target too, e.g.
+    '3.10.7 (stable) (Tue Dec 23 ...) on "ios_arm64"'. It is not dependable on
+    its own: beta and dev channel engines do not always carry one. So the
+    target is read from the image — its header names the architecture and
+    LC_BUILD_VERSION names the platform — and the string supplies only the Dart
+    version, with the engine ids left for the caller to look up when it is
+    absent.
+
+    Note a macOS engine embeds engine ids exactly as an ELF one does, while an
+    iOS engine embeds none, so the lookup can rescue the first and not the
+    second.
+    """
     macho = MachO(flutter_file)
-    m = re.search(br'([\d][\w\.\-]*) \((?:stable|beta|dev)\) \([^)]*\) on "(ios|macos)_(arm64|x64)"', macho.slice_data())
-    assert m is not None, 'Cannot find the Dart version in the Flutter framework'
-    dart_version = m.group(1).decode()
-    os_name = m.group(2).decode()
-    arch = m.group(3).decode()
-    # engine ids are only used to look up an unknown Dart version
-    return [], dart_version, arch, os_name
+    data = macho.slice_data()
+
+    m = re.search(br'([\d][\w\.\-]*) \((?:stable|beta|dev)\) \([^)]*\) on "(ios|macos)_(arm64|x64)"', data)
+    dart_version = m.group(1).decode() if m is not None else None
+
+    arch = macho.arch()
+    assert arch is not None, f'Unsupported architecture: cputype {macho.cputype:#x}'
+    # the string is the only fallback for the platform, and only older images
+    # lack LC_BUILD_VERSION
+    os_name = macho.os_name() or (m.group(2).decode() if m is not None else None)
+    assert os_name is not None, 'Cannot determine whether this is an iOS or macOS image'
+
+    engine_ids = [h.decode() for h in re.findall(b'\x00([a-f\\d]{40})(?=\x00)', data)]
+
+    return engine_ids, dart_version, arch, os_name
 
 
 def extract_snapshot_hash_flags(libapp_file):
@@ -230,32 +269,26 @@ def get_dart_commit(url):
     return commit_id, dart_version
 
 def extract_dart_info(libapp_file: str, libflutter_file: str):
-    # An iOS application ships Mach-O images instead of libapp.so/libflutter.so
+    # An iOS or macOS application ships Mach-O images instead of
+    # libapp.so/libflutter.so
     if is_macho(libapp_file):
         snapshot_hash, flags = extract_snapshot_hash_flags_macho(libapp_file)
-        _, dart_version, arch, os_name = extract_flutter_framework_info(libflutter_file)
-        return dart_version, snapshot_hash, flags, arch, os_name
+        engine_ids, dart_version, arch, os_name = extract_flutter_framework_info(libflutter_file)
+    else:
+        snapshot_hash, flags = extract_snapshot_hash_flags(libapp_file)
+        engine_ids, dart_version, arch, os_name = extract_libflutter_info(libflutter_file)
 
-    snapshot_hash, flags = extract_snapshot_hash_flags(libapp_file)
-    #print('snapshot hash', snapshot_hash)
-    #print(flags)
-
-    engine_ids, dart_version, arch, os_name = extract_libflutter_info(libflutter_file)
-    # print('possible engine ids', engine_ids)
-    # print('dart version', dart_version)
-
+    # A beta or dev channel engine does not always name its Dart version. The
+    # engine ids beside it identify the SDK it was built from, so ask the
+    # archive. Both image formats get this; only ELF used to.
     if dart_version is None:
         engine_id, sdk_url, sdk_size = get_dart_sdk_url_size(engine_ids)
-        # print(engine_id)
-        # print(sdk_url)
-        # print(sdk_size)
-
+        assert sdk_url is not None, (
+            'Cannot determine the Dart version: the engine names no version and '
+            f'{"none of its engine ids match a published SDK" if engine_ids else "carries no engine ids"}. '
+            'Pass --dart-version to say which one to build.')
         commit_id, dart_version = get_dart_commit(sdk_url)
-        # print(commit_id)
-        # print(dart_version)
-        #assert dart_version == dart_version_sdk
-    
-    # TODO: os (android or ios) and architecture (arm64 or x64)
+
     return dart_version, snapshot_hash, flags, arch, os_name
 
 

--- a/extract_dart_info.py
+++ b/extract_dart_info.py
@@ -11,7 +11,115 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.enums import ENUM_E_MACHINE 
 from elftools.elf.sections import SymbolTableSection
 
-# TODO: support both ELF and Mach-O file
+MH_MAGIC_64 = b'\xcf\xfa\xed\xfe'
+FAT_MAGIC = b'\xca\xfe\xba\xbe'  # a fat header is always stored big endian
+FAT_CIGAM = b'\xbe\xba\xfe\xca'
+LC_SYMTAB = 0x2
+LC_SEGMENT_64 = 0x19
+N_STAB = 0xe0
+N_TYPE = 0x0e
+N_SECT = 0x0e
+CPU_TYPE_X86_64 = 0x01000007
+CPU_TYPE_ARM64 = 0x0100000c
+
+
+def is_macho(path):
+    with open(path, 'rb') as f:
+        return f.read(4) in (MH_MAGIC_64, FAT_MAGIC, FAT_CIGAM)
+
+
+class MachO:
+    """Just enough Mach-O to find a symbol and read the bytes at it.
+
+    An iOS application has no libapp.so/libflutter.so. It ships
+    App.framework/App and Flutter.framework/Flutter instead, both Mach-O.
+    """
+
+    def __init__(self, path):
+        with open(path, 'rb') as f:
+            self.data = f.read()
+
+        self.slice_off = self._find_slice()
+        magic = self.data[self.slice_off:self.slice_off + 4]
+        assert magic == MH_MAGIC_64, f'Unsupported Mach-O image: {magic.hex()}'
+
+        _, _, _, _, ncmds, _, _, _ = unpack('<IiiIIIII', self._read(0, 32))
+        self.segments = []  # (vmaddr, vmsize, fileoff, filesize)
+        self.symtab = None  # (symoff, nsyms, stroff, strsize)
+        off = 32
+        for _ in range(ncmds):
+            cmd, cmdsize = unpack('<II', self._read(off, 8))
+            if cmd == LC_SEGMENT_64:
+                vmaddr, vmsize, fileoff, filesize = unpack('<QQQQ', self._read(off + 24, 32))
+                self.segments.append((vmaddr, vmsize, fileoff, filesize))
+            elif cmd == LC_SYMTAB:
+                self.symtab = unpack('<IIII', self._read(off + 8, 16))
+            off += cmdsize
+
+    def _find_slice(self):
+        if self.data[:4] not in (FAT_MAGIC, FAT_CIGAM):
+            return 0
+        # Prefer arm64, which is what Flutter ships for devices.
+        count = unpack('>I', self.data[4:8])[0]
+        fallback = None
+        for i in range(count):
+            cputype, _, offset, _, _ = unpack('>iIIII', self.data[8 + i * 20:28 + i * 20])
+            if cputype == CPU_TYPE_ARM64:
+                return offset
+            if cputype == CPU_TYPE_X86_64 and fallback is None:
+                fallback = offset
+        assert fallback is not None, 'No arm64 or x64 image in the universal binary'
+        return fallback
+
+    def _read(self, offset, size):
+        start = self.slice_off + offset
+        return self.data[start:start + size]
+
+    def vm_to_file(self, addr):
+        for vmaddr, vmsize, fileoff, filesize in self.segments:
+            if vmaddr <= addr < vmaddr + vmsize:
+                return fileoff + (addr - vmaddr)
+        return None
+
+    def read_at_symbol(self, name, size):
+        assert self.symtab is not None, 'Mach-O has no symbol table'
+        symoff, nsyms, stroff, strsize = self.symtab
+        wanted = name.encode()
+        for i in range(nsyms):
+            n_strx, n_type, _, _, n_value = unpack('<IBBHQ', self._read(symoff + i * 16, 16))
+            if (n_type & N_STAB) != 0 or (n_type & N_TYPE) != N_SECT or n_strx >= strsize:
+                continue
+            end = self.data.index(b'\0', self.slice_off + stroff + n_strx)
+            if self.data[self.slice_off + stroff + n_strx:end] == wanted:
+                return self._read(self.vm_to_file(n_value), size)
+        return None
+
+
+def extract_snapshot_hash_flags_macho(app_file):
+    macho = MachO(app_file)
+    # snapshot header: magic, length and kind take 20 bytes, then the version
+    # hash followed by the feature string, same as in an ELF libapp.so.
+    data = macho.read_at_symbol('_kDartVmSnapshotData', 20 + 32 + 256)
+    assert data is not None, 'Cannot find _kDartVmSnapshotData'
+    snapshot_hash = data[20:52].decode()
+    flags = data[52:]
+    flags = flags[:flags.index(b'\0')].decode().strip().split(' ')
+    return snapshot_hash, flags
+
+
+def extract_flutter_framework_info(flutter_file):
+    # The engine embeds the Dart VM version string, which names the target
+    # directly, e.g. '3.10.7 (stable) (Tue Dec 23 ...) on "ios_arm64"'.
+    macho = MachO(flutter_file)
+    m = re.search(br'([\d][\w\.\-]*) \((?:stable|beta|dev)\) \([^)]*\) on "(ios|macos)_(arm64|x64)"', macho.data)
+    assert m is not None, 'Cannot find the Dart version in the Flutter framework'
+    dart_version = m.group(1).decode()
+    os_name = m.group(2).decode()
+    arch = m.group(3).decode()
+    # engine ids are only used to look up an unknown Dart version
+    return [], dart_version, arch, os_name
+
+
 def extract_snapshot_hash_flags(libapp_file):
     with open(libapp_file, 'rb') as f:
         elf = ELFFile(f)
@@ -102,6 +210,12 @@ def get_dart_commit(url):
     return commit_id, dart_version
 
 def extract_dart_info(libapp_file: str, libflutter_file: str):
+    # An iOS application ships Mach-O images instead of libapp.so/libflutter.so
+    if is_macho(libapp_file):
+        snapshot_hash, flags = extract_snapshot_hash_flags_macho(libapp_file)
+        _, dart_version, arch, os_name = extract_flutter_framework_info(libflutter_file)
+        return dart_version, snapshot_hash, flags, arch, os_name
+
     snapshot_hash, flags = extract_snapshot_hash_flags(libapp_file)
     #print('snapshot hash', snapshot_hash)
     #print(flags)

--- a/extract_dart_info.py
+++ b/extract_dart_info.py
@@ -14,6 +14,8 @@ from elftools.elf.sections import SymbolTableSection
 MH_MAGIC_64 = b'\xcf\xfa\xed\xfe'
 FAT_MAGIC = b'\xca\xfe\xba\xbe'  # a fat header is always stored big endian
 FAT_CIGAM = b'\xbe\xba\xfe\xca'
+FAT_MAGIC_64 = b'\xca\xfe\xba\xbf'  # fat_arch_64 entries, not supported
+FAT_CIGAM_64 = b'\xbf\xba\xfe\xca'
 LC_SYMTAB = 0x2
 LC_SEGMENT_64 = 0x19
 N_STAB = 0xe0
@@ -57,6 +59,10 @@ class MachO:
             off += cmdsize
 
     def _find_slice(self):
+        # A 64-bit fat header uses 32-byte entries rather than 20, so parsing it
+        # as a 32-bit one silently yields nonsense offsets. Say so instead.
+        assert self.data[:4] not in (FAT_MAGIC_64, FAT_CIGAM_64), \
+            'Universal binary with a 64-bit fat header (FAT_MAGIC_64) is not supported'
         if self.data[:4] not in (FAT_MAGIC, FAT_CIGAM):
             return 0
         # Prefer arm64, which is what Flutter ships for devices.

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -26,8 +26,8 @@ string(SUBSTRING ${PROJECT_NAME} 6 -1 DART_VERSION)
 if (NOT DEFINED TARGET_OS)
 	set(TARGET_OS "android")
 endif()
-if (NOT "${TARGET_OS}" MATCHES "^(android|ios)$")
-	message(FATAL_ERROR "Only android or ios platform")
+if (NOT "${TARGET_OS}" MATCHES "^(android|ios|macos)$")
+	message(FATAL_ERROR "Only android, ios or macos platform")
 endif()
 
 if (NOT DEFINED TARGET_ARCH)
@@ -54,16 +54,21 @@ set_target_properties(${LIBNAME} PROPERTIES
 	VISIBILITY_INLINES_HIDDEN ON
 	POSITION_INDEPENDENT_CODE ON)
 
-# DART_TARGET_OS_ANDROID or DART_TARGET_OS_MACOS(+_IOS)
+# DART_TARGET_OS_ANDROID, DART_TARGET_OS_MACOS, or both MACOS and MACOS_IOS
 if (${TARGET_OS} STREQUAL "android")
 	set(target_os "DART_TARGET_OS_ANDROID")
 	# Note: DART_COMPRESSED_POINTERS should be from the binary
 	#set(dart_pointers "DART_COMPRESSED_POINTERS")
-else()
+elseif (${TARGET_OS} STREQUAL "ios")
 	# A real Dart iOS build defines both (see runtime/platform/globals.h).
 	# Code such as Dart::VersionString() tests DART_TARGET_OS_MACOS first and
 	# only then the _IOS sub-flag, so defining _IOS alone fails to compile.
 	set(target_os "DART_TARGET_OS_MACOS" "DART_TARGET_OS_MACOS_IOS")
+else()
+	# macOS: DART_TARGET_OS_MACOS alone. The _IOS sub-flag selects iOS-specific
+	# behaviour, so defining it for a desktop target would misreport the target
+	# and take iOS code paths.
+	set(target_os "DART_TARGET_OS_MACOS")
 endif()
 # TARGET_ARCH_ARM64 or TARGET_ARCH_X64
 if (${TARGET_ARCH} STREQUAL "arm64")

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -54,13 +54,16 @@ set_target_properties(${LIBNAME} PROPERTIES
 	VISIBILITY_INLINES_HIDDEN ON
 	POSITION_INDEPENDENT_CODE ON)
 
-# DART_TARGET_OS_ANDROID or DART_TARGET_OS_MACOS_IOS
+# DART_TARGET_OS_ANDROID or DART_TARGET_OS_MACOS(+_IOS)
 if (${TARGET_OS} STREQUAL "android")
 	set(target_os "DART_TARGET_OS_ANDROID")
 	# Note: DART_COMPRESSED_POINTERS should be from the binary
 	#set(dart_pointers "DART_COMPRESSED_POINTERS")
 else()
-	set(target_os "DART_TARGET_OS_MACOS_IOS")
+	# A real Dart iOS build defines both (see runtime/platform/globals.h).
+	# Code such as Dart::VersionString() tests DART_TARGET_OS_MACOS first and
+	# only then the _IOS sub-flag, so defining _IOS alone fails to compile.
+	set(target_os "DART_TARGET_OS_MACOS" "DART_TARGET_OS_MACOS_IOS")
 endif()
 # TARGET_ARCH_ARM64 or TARGET_ARCH_X64
 if (${TARGET_ARCH} STREQUAL "arm64")

--- a/tests/fat_macho.py
+++ b/tests/fat_macho.py
@@ -20,21 +20,52 @@ CPU_TYPE_ARM64 = 0x0100000C
 MH_DYLIB = 0x6
 DEFAULT_ALIGN = 14  # 2**14 = 16384, what Apple's tooling uses
 
+LC_BUILD_VERSION = 0x32
 
-def thin_macho64(cputype: int = CPU_TYPE_ARM64, body: bytes = b"") -> bytes:
-    """A minimal but structurally valid 64-bit thin Mach-O with no load commands."""
+PLATFORM_MACOS = 1
+PLATFORM_IOS = 2
+
+
+def build_version_command(platform: int) -> bytes:
+    """An LC_BUILD_VERSION load command, which names the target platform.
+
+    Both a real iOS and a real macOS Flutter engine carry one, so it is a more
+    dependable source of the target than any embedded string.
+    """
+    return struct.pack(
+        "<IIIIII",
+        LC_BUILD_VERSION,
+        24,  # cmdsize, no tool entries
+        platform,
+        0,  # minos
+        0,  # sdk
+        0,  # ntools
+    )
+
+
+def thin_macho64(
+    cputype: int = CPU_TYPE_ARM64,
+    body: bytes = b"",
+    commands: "list[bytes] | None" = None,
+) -> bytes:
+    """A minimal but structurally valid 64-bit thin Mach-O.
+
+    `commands` are whole load commands, already packed.
+    """
+    commands = list(commands or [])
+    payload = b"".join(commands)
     header = struct.pack(
         "<IiiIIIII",
         MH_MAGIC_64,
         cputype,
         0,  # cpusubtype
         MH_DYLIB,  # filetype
-        0,  # ncmds
-        0,  # sizeofcmds
+        len(commands),  # ncmds
+        len(payload),  # sizeofcmds
         0,  # flags
         0,  # reserved
     )
-    return header + body
+    return header + payload + body
 
 
 def build_fat(slices: list[tuple[int, bytes]], align: int = DEFAULT_ALIGN) -> bytes:

--- a/tests/fat_macho.py
+++ b/tests/fat_macho.py
@@ -1,0 +1,79 @@
+"""Build universal (fat) Mach-O images for tests, without needing macOS.
+
+A fat binary is a big-endian header listing architecture slices, each slice a
+complete thin Mach-O at some offset. Committing a real universal binary is not
+an option — they are hundreds of megabytes of third-party software — so tests
+synthesize one around whatever thin image they have.
+
+Standard library only.
+"""
+
+import struct
+
+FAT_MAGIC = 0xCAFEBABE
+FAT_MAGIC_64 = 0xCAFEBABF  # fat_arch_64 entries; not currently supported
+MH_MAGIC_64 = 0xFEEDFACF
+
+CPU_TYPE_X86_64 = 0x01000007
+CPU_TYPE_ARM64 = 0x0100000C
+
+MH_DYLIB = 0x6
+DEFAULT_ALIGN = 14  # 2**14 = 16384, what Apple's tooling uses
+
+
+def thin_macho64(cputype: int = CPU_TYPE_ARM64, body: bytes = b"") -> bytes:
+    """A minimal but structurally valid 64-bit thin Mach-O with no load commands."""
+    header = struct.pack(
+        "<IiiIIIII",
+        MH_MAGIC_64,
+        cputype,
+        0,  # cpusubtype
+        MH_DYLIB,  # filetype
+        0,  # ncmds
+        0,  # sizeofcmds
+        0,  # flags
+        0,  # reserved
+    )
+    return header + body
+
+
+def build_fat(slices: list[tuple[int, bytes]], align: int = DEFAULT_ALIGN) -> bytes:
+    """Wrap `slices` — (cputype, thin image) pairs — in a fat container.
+
+    Slice order is preserved, which is the point: a real universal binary may
+    list x86_64 before arm64, and selection must not depend on position.
+    """
+    alignment = 1 << align
+    header_size = 8 + 20 * len(slices)
+
+    offsets = []
+    cursor = (header_size + alignment - 1) // alignment * alignment
+    for _, data in slices:
+        offsets.append(cursor)
+        cursor = (cursor + len(data) + alignment - 1) // alignment * alignment
+
+    out = bytearray(struct.pack(">II", FAT_MAGIC, len(slices)))
+    for (cputype, data), offset in zip(slices, offsets):
+        out += struct.pack(">iIIII", cputype, 0, offset, len(data), align)
+
+    for (_, data), offset in zip(slices, offsets):
+        out += b"\x00" * (offset - len(out))
+        out += data
+
+    return bytes(out)
+
+
+def build_fat64_header(slices: list[tuple[int, bytes]]) -> bytes:
+    """A FAT_MAGIC_64 header, which uses 32-byte fat_arch_64 entries.
+
+    Only the header is needed: the point is that the format is recognisably a
+    universal binary that the current readers do not support, and that they say
+    so rather than misparsing it.
+    """
+    out = bytearray(struct.pack(">II", FAT_MAGIC_64, len(slices)))
+    offset = 8 + 32 * len(slices)
+    for cputype, data in slices:
+        out += struct.pack(">iIQQI", cputype, 0, offset, len(data), DEFAULT_ALIGN)
+        out += b"\x00" * 4  # reserved
+        offset += len(data)
+    return bytes(out)

--- a/tests/test_dart_lib_info.py
+++ b/tests/test_dart_lib_info.py
@@ -14,17 +14,24 @@ Standard library only, but imports dartvm_fetch_build; run with the interpreter
 Blutter itself uses.
 """
 
+import os
 import pathlib
 import sys
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
+# A runner asks for strict mode so a failed dependency install fails the run
+# instead of quietly skipping. Sample-driven skips stay skips.
+STRICT = os.environ.get("BLUTTER_TESTS_STRICT") == "1"
+
 try:
     from dartvm_fetch_build import DartLibInfo
 
     IMPORT_ERROR = None
 except ImportError as exc:  # pragma: no cover - depends on the environment
+    if STRICT:
+        raise
     DartLibInfo = None
     IMPORT_ERROR = str(exc)
 

--- a/tests/test_dart_lib_info.py
+++ b/tests/test_dart_lib_info.py
@@ -1,0 +1,54 @@
+"""Defaults chosen for a Dart VM build when the snapshot flags are unavailable.
+
+`DartLibInfo` derives pointer compression from the target when the caller does
+not supply it — the `--dart-version` path, where there is no snapshot to read
+flags from.
+
+Android uses compressed pointers; iOS does not. macOS does not either, which
+the default originally got wrong by testing only for iOS. Checked against a
+real app: AppFlowy 0.13.1 (Dart 3.11.5, macos arm64) ships
+
+    ... arm64 macos no-compressed-pointers
+
+Standard library only, but imports dartvm_fetch_build; run with the interpreter
+Blutter itself uses.
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+try:
+    from dartvm_fetch_build import DartLibInfo
+
+    IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover - depends on the environment
+    DartLibInfo = None
+    IMPORT_ERROR = str(exc)
+
+
+@unittest.skipIf(DartLibInfo is None, f"dartvm_fetch_build not importable: {IMPORT_ERROR}")
+class CompressedPointerDefaultTests(unittest.TestCase):
+    def test_android_defaults_to_compressed(self):
+        self.assertTrue(DartLibInfo("3.11.5", "android", "arm64").has_compressed_ptrs)
+
+    def test_ios_defaults_to_uncompressed(self):
+        self.assertFalse(DartLibInfo("3.10.7", "ios", "arm64").has_compressed_ptrs)
+
+    def test_macos_defaults_to_uncompressed(self):
+        self.assertFalse(DartLibInfo("3.11.5", "macos", "arm64").has_compressed_ptrs)
+
+    def test_an_explicit_value_always_wins(self):
+        """The normal path reads the snapshot flags and passes them in."""
+        self.assertTrue(DartLibInfo("3.11.5", "macos", "arm64", True).has_compressed_ptrs)
+        self.assertFalse(DartLibInfo("3.11.5", "android", "arm64", False).has_compressed_ptrs)
+
+    def test_lib_name_carries_the_target(self):
+        info = DartLibInfo("3.11.5", "macos", "arm64")
+        self.assertEqual(info.lib_name, "dartvm3.11.5_macos_arm64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_id_fallback.py
+++ b/tests/test_engine_id_fallback.py
@@ -1,0 +1,209 @@
+"""Recovering the Dart version when the engine does not name it.
+
+Issue #4: the ELF path handles an engine whose Dart version string is absent —
+beta and dev channel builds do not always carry one — by collecting the engine
+ids embedded alongside it and looking them up against the Flutter SDK archive.
+The Mach-O path asserted instead, so such an app failed outright.
+
+Two facts from real binaries shape this, both checked rather than assumed:
+
+- A macOS engine embeds engine ids exactly as an ELF one does (AppFlowy 0.13.1
+  carries two). An **iOS** engine embeds none — the only 40-hex runs in one are
+  byte tables, not strings. So the lookup can rescue a macOS app and cannot
+  rescue an iOS one, and the iOS case has to fail with something a reader can
+  act on.
+- Both carry `LC_BUILD_VERSION` naming the platform, and their header names the
+  architecture. Reading those rather than the version string is what lets the
+  target survive the string being missing at all.
+
+Standard library only; imports extract_dart_info, so run with the interpreter
+Blutter itself uses.
+"""
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from fat_macho import (  # noqa: E402
+    CPU_TYPE_ARM64,
+    CPU_TYPE_X86_64,
+    PLATFORM_IOS,
+    PLATFORM_MACOS,
+    build_version_command,
+    thin_macho64,
+)
+
+STRICT = os.environ.get("BLUTTER_TESTS_STRICT") == "1"
+
+try:
+    from extract_dart_info import extract_flutter_framework_info
+
+    IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover - depends on the environment
+    if STRICT:
+        raise
+    extract_flutter_framework_info = None
+    IMPORT_ERROR = str(exc)
+
+ENGINE_ID_A = "42d3d75a56ef1f1a3b0c9e8d7f6a5b4c3d2e1f00"
+ENGINE_ID_B = "a183ded9ad6712345678901234567890abcdef12"
+
+
+def engine_ids_blob(*ids: str) -> bytes:
+    """Engine ids as the linker leaves them: NUL-delimited C strings."""
+    return b"\x00" + b"\x00".join(i.encode() for i in ids) + b"\x00"
+
+
+def version_blob(version: str = "3.10.7", target: str = "ios_arm64") -> bytes:
+    return f'\x00{version} (stable) (Mon Jan 1 00:00:00 2026 +0000) on "{target}"\x00'.encode()
+
+
+def write(tmp: str, data: bytes) -> str:
+    path = os.path.join(tmp, "Flutter")
+    with open(path, "wb") as f:
+        f.write(data)
+    return path
+
+
+@unittest.skipIf(
+    extract_flutter_framework_info is None, f"extract_dart_info not importable: {IMPORT_ERROR}"
+)
+class EngineFallbackTests(unittest.TestCase):
+    def test_version_string_is_used_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                tmp,
+                thin_macho64(
+                    CPU_TYPE_ARM64,
+                    version_blob("3.10.7", "ios_arm64"),
+                    [build_version_command(PLATFORM_IOS)],
+                ),
+            )
+            engine_ids, version, arch, os_name = extract_flutter_framework_info(path)
+            self.assertEqual((version, arch, os_name), ("3.10.7", "arm64", "ios"))
+
+    def test_engine_ids_are_collected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                tmp,
+                thin_macho64(
+                    CPU_TYPE_ARM64,
+                    engine_ids_blob(ENGINE_ID_A, ENGINE_ID_B) + version_blob(),
+                    [build_version_command(PLATFORM_IOS)],
+                ),
+            )
+            engine_ids, _, _, _ = extract_flutter_framework_info(path)
+            self.assertEqual(engine_ids, [ENGINE_ID_A, ENGINE_ID_B])
+
+    def test_missing_version_string_is_not_fatal(self):
+        """The beta/dev case. Returning None hands the caller the lookup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                tmp,
+                thin_macho64(
+                    CPU_TYPE_ARM64,
+                    engine_ids_blob(ENGINE_ID_A, ENGINE_ID_B),
+                    [build_version_command(PLATFORM_MACOS)],
+                ),
+            )
+            engine_ids, version, arch, os_name = extract_flutter_framework_info(path)
+            self.assertIsNone(version)
+            self.assertEqual(engine_ids, [ENGINE_ID_A, ENGINE_ID_B])
+            self.assertEqual((arch, os_name), ("arm64", "macos"))
+
+    def test_target_survives_a_missing_version_string(self):
+        """Without the string there is nothing else to read the target from."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                tmp,
+                thin_macho64(
+                    CPU_TYPE_X86_64, b"", [build_version_command(PLATFORM_MACOS)]
+                ),
+            )
+            _, version, arch, os_name = extract_flutter_framework_info(path)
+            self.assertIsNone(version)
+            self.assertEqual((arch, os_name), ("x64", "macos"))
+
+    def test_header_wins_over_a_disagreeing_version_string(self):
+        """The header describes the image; the string describes whatever build
+        wrote it, and a universal binary carries one per slice."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                tmp,
+                thin_macho64(
+                    CPU_TYPE_ARM64,
+                    version_blob("3.11.5", "macos_x64"),
+                    [build_version_command(PLATFORM_MACOS)],
+                ),
+            )
+            _, version, arch, os_name = extract_flutter_framework_info(path)
+            self.assertEqual((version, arch, os_name), ("3.11.5", "arm64", "macos"))
+
+    def test_platform_falls_back_to_the_version_string(self):
+        """Older images carry no LC_BUILD_VERSION."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(tmp, thin_macho64(CPU_TYPE_ARM64, version_blob("3.10.7", "ios_arm64")))
+            _, version, arch, os_name = extract_flutter_framework_info(path)
+            self.assertEqual((version, arch, os_name), ("3.10.7", "arm64", "ios"))
+
+    def test_nothing_to_go_on_reports_what_to_do(self):
+        """An iOS engine carries no engine ids, so a missing version string
+        cannot be recovered. Say so, and name the way out."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                tmp, thin_macho64(CPU_TYPE_ARM64, b"", [build_version_command(PLATFORM_IOS)])
+            )
+            engine_ids, version, _, _ = extract_flutter_framework_info(path)
+            self.assertIsNone(version)
+            self.assertEqual(engine_ids, [])
+
+
+REAL_IOS = os.environ.get("BLUTTER_TEST_IOS_ENGINE")
+REAL_MACOS = os.environ.get("BLUTTER_TEST_MACOS_ENGINE")
+
+
+@unittest.skipUnless(
+    extract_flutter_framework_info is not None
+    and REAL_IOS
+    and pathlib.Path(REAL_IOS).is_file(),
+    "set BLUTTER_TEST_IOS_ENGINE to a real Flutter.framework/Flutter",
+)
+class RealIosEngineTests(unittest.TestCase):
+    def test_detection_is_unchanged(self):
+        _, version, arch, os_name = extract_flutter_framework_info(REAL_IOS)
+        self.assertEqual((arch, os_name), ("arm64", "ios"))
+        self.assertIsNotNone(version)
+
+    def test_ios_engines_carry_no_engine_ids(self):
+        """Recorded because it is the reason the lookup cannot rescue iOS."""
+        engine_ids, _, _, _ = extract_flutter_framework_info(REAL_IOS)
+        self.assertEqual(engine_ids, [])
+
+
+@unittest.skipUnless(
+    extract_flutter_framework_info is not None
+    and REAL_MACOS
+    and pathlib.Path(REAL_MACOS).is_file(),
+    "set BLUTTER_TEST_MACOS_ENGINE to a real FlutterMacOS",
+)
+class RealMacosEngineTests(unittest.TestCase):
+    def test_detection_is_unchanged(self):
+        _, version, arch, os_name = extract_flutter_framework_info(REAL_MACOS)
+        self.assertEqual((arch, os_name), ("arm64", "macos"))
+        self.assertIsNotNone(version)
+
+    def test_macos_engines_do_carry_engine_ids(self):
+        """Which is what makes the fallback worth having at all."""
+        engine_ids, _, _, _ = extract_flutter_framework_info(REAL_MACOS)
+        self.assertEqual(len(engine_ids), 2)
+        for engine_id in engine_ids:
+            self.assertRegex(engine_id, r"^[0-9a-f]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fat_macho.py
+++ b/tests/test_fat_macho.py
@@ -1,0 +1,202 @@
+"""Universal (fat) Mach-O slice selection, in both readers.
+
+Issue #5: `MachOHelper::MapLibApp` (C++) and `MachO._find_slice` (Python) both
+parse a fat header and prefer the arm64 slice, and neither had ever run against
+a universal binary.
+
+The ordering cases matter more than they look. A real universal build — checked
+against AppFlowy 0.13.1 macos-universal — lists **x86_64 first** and arm64
+second, so an implementation that quietly takes the first slice picks the wrong
+architecture and fails later, somewhere unrelated.
+
+Fixtures are synthesized (see fat_macho.py) rather than committed: a real
+universal binary is hundreds of megabytes of third-party software. The
+integration test below wraps a *real* thin image supplied via the environment,
+so the synthetic path is checked against genuine Mach-O content at least once.
+
+The unit tests need `extract_dart_info`, which imports requests and pyelftools;
+run them with the interpreter Blutter itself uses.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from fat_macho import (  # noqa: E402
+    CPU_TYPE_ARM64,
+    CPU_TYPE_X86_64,
+    build_fat,
+    build_fat64_header,
+    thin_macho64,
+)
+
+try:
+    from extract_dart_info import MachO, is_macho
+
+    IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover - depends on the environment
+    MachO = None
+    is_macho = None
+    IMPORT_ERROR = str(exc)
+
+CPU_TYPE_PPC = 0x00000012  # something neither reader supports
+
+
+def write(tmpdir: str, name: str, data: bytes) -> str:
+    path = os.path.join(tmpdir, name)
+    with open(path, "wb") as f:
+        f.write(data)
+    return path
+
+
+@unittest.skipIf(MachO is None, f"extract_dart_info not importable: {IMPORT_ERROR}")
+class FindSliceTests(unittest.TestCase):
+    """The Python reader."""
+
+    def test_thin_image_has_no_slice_offset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(tmp, "thin", thin_macho64(CPU_TYPE_ARM64))
+            self.assertEqual(MachO(path).slice_off, 0)
+
+    def test_prefers_arm64_when_x86_64_is_listed_first(self):
+        """The layout a real universal binary actually uses."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fat = build_fat(
+                [
+                    (CPU_TYPE_X86_64, thin_macho64(CPU_TYPE_X86_64, b"\x11" * 64)),
+                    (CPU_TYPE_ARM64, thin_macho64(CPU_TYPE_ARM64, b"\x22" * 64)),
+                ]
+            )
+            path = write(tmp, "fat", fat)
+            macho = MachO(path)
+            self.assertGreater(macho.slice_off, 0)
+            self.assertEqual(macho.data[macho.slice_off + 4 : macho.slice_off + 8][:1], b"\x0c")
+
+    def test_prefers_arm64_when_it_is_listed_first(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fat = build_fat(
+                [
+                    (CPU_TYPE_ARM64, thin_macho64(CPU_TYPE_ARM64, b"\x22" * 64)),
+                    (CPU_TYPE_X86_64, thin_macho64(CPU_TYPE_X86_64, b"\x11" * 64)),
+                ]
+            )
+            path = write(tmp, "fat", fat)
+            self.assertEqual(MachO(path).slice_off, 1 << 14)
+
+    def test_falls_back_to_x86_64(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fat = build_fat([(CPU_TYPE_X86_64, thin_macho64(CPU_TYPE_X86_64, b"\x11" * 64))])
+            path = write(tmp, "fat", fat)
+            self.assertEqual(MachO(path).slice_off, 1 << 14)
+
+    def test_rejects_a_universal_binary_with_no_supported_slice(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fat = build_fat([(CPU_TYPE_PPC, thin_macho64(CPU_TYPE_PPC, b"\x33" * 64))])
+            path = write(tmp, "fat", fat)
+            with self.assertRaises(AssertionError):
+                MachO(path)
+
+    def test_is_macho_recognises_a_fat_image(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fat = build_fat([(CPU_TYPE_ARM64, thin_macho64(CPU_TYPE_ARM64))])
+            self.assertTrue(is_macho(write(tmp, "fat", fat)))
+
+    def test_fat_magic_64_fails_loudly_rather_than_misparsing(self):
+        """FAT_MAGIC_64 uses 32-byte entries; misreading them silently is worse
+        than refusing the file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data = build_fat64_header([(CPU_TYPE_ARM64, thin_macho64(CPU_TYPE_ARM64))])
+            path = write(tmp, "fat64", data)
+            with self.assertRaises(AssertionError):
+                MachO(path)
+
+
+BLUTTER_BIN = os.environ.get("BLUTTER_BIN")
+THIN_SAMPLE = os.environ.get("BLUTTER_TEST_MACHO")
+
+
+@unittest.skipUnless(
+    BLUTTER_BIN
+    and pathlib.Path(BLUTTER_BIN).is_file()
+    and THIN_SAMPLE
+    and pathlib.Path(THIN_SAMPLE).is_file(),
+    "set BLUTTER_BIN and BLUTTER_TEST_MACHO (a thin arm64 App) for the loader test",
+)
+class LoaderTests(unittest.TestCase):
+    """The C++ reader, exercised through the executable.
+
+    Wrapping a real thin App in a fat container and analyzing it must produce
+    exactly what analyzing the thin image produces — the container is the only
+    difference.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        tmp = pathlib.Path(cls._tmp.name)
+
+        thin = pathlib.Path(THIN_SAMPLE).read_bytes()
+        # x86_64 first, matching how real universal binaries are laid out.
+        fat = build_fat(
+            [
+                (CPU_TYPE_X86_64, thin_macho64(CPU_TYPE_X86_64, b"\x00" * 4096)),
+                (CPU_TYPE_ARM64, thin),
+            ]
+        )
+        cls.fat_path = tmp / "App_fat"
+        cls.fat_path.write_bytes(fat)
+
+        cls.thin_out = tmp / "thin_out"
+        cls.fat_out = tmp / "fat_out"
+        cls.thin_result = cls.run_blutter(THIN_SAMPLE, cls.thin_out)
+        cls.fat_result = cls.run_blutter(str(cls.fat_path), cls.fat_out)
+
+    @staticmethod
+    def run_blutter(infile: str, outdir: pathlib.Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [BLUTTER_BIN, "-i", infile, "-o", str(outdir)],
+            capture_output=True,
+            text=True,
+            timeout=1800,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def test_thin_baseline_succeeds(self):
+        """If this fails the comparison below proves nothing."""
+        self.assertEqual(self.thin_result.returncode, 0, self.thin_result.stderr[-2000:])
+
+    def test_fat_image_is_analyzed(self):
+        self.assertEqual(self.fat_result.returncode, 0, self.fat_result.stderr[-2000:])
+
+    def test_fat_and_thin_produce_the_same_files(self):
+        thin_files = {p.relative_to(self.thin_out) for p in self.thin_out.rglob("*") if p.is_file()}
+        fat_files = {p.relative_to(self.fat_out) for p in self.fat_out.rglob("*") if p.is_file()}
+        self.assertEqual(thin_files, fat_files)
+        self.assertGreater(len(thin_files), 0, "no output at all")
+
+    def test_fat_and_thin_disassembly_agree(self):
+        """Compared after masking host addresses, which vary run to run."""
+        import re
+
+        host = re.compile(r"0x[0-9a-f]{10,}|\b\d{12,}\b|@[0-9a-f]{8}")
+        differing = []
+        for thin_file in sorted(self.thin_out.rglob("*.dart")):
+            fat_file = self.fat_out / thin_file.relative_to(self.thin_out)
+            a = host.sub("X", thin_file.read_text(errors="replace"))
+            b = host.sub("X", fat_file.read_text(errors="replace"))
+            if a != b:
+                differing.append(str(thin_file.relative_to(self.thin_out)))
+        self.assertEqual(differing[:5], [], f"{len(differing)} files differ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fat_macho.py
+++ b/tests/test_fat_macho.py
@@ -36,11 +36,17 @@ from fat_macho import (  # noqa: E402
     thin_macho64,
 )
 
+# A runner asks for strict mode so a failed dependency install fails the run
+# instead of quietly skipping. Sample-driven skips stay skips.
+STRICT = os.environ.get("BLUTTER_TESTS_STRICT") == "1"
+
 try:
     from extract_dart_info import MachO, is_macho
 
     IMPORT_ERROR = None
 except ImportError as exc:  # pragma: no cover - depends on the environment
+    if STRICT:
+        raise
     MachO = None
     is_macho = None
     IMPORT_ERROR = str(exc)

--- a/tests/test_fat_macho.py
+++ b/tests/test_fat_macho.py
@@ -117,6 +117,63 @@ class FindSliceTests(unittest.TestCase):
                 MachO(path)
 
 
+def version_string(arch: str, version: str = "3.11.5") -> bytes:
+    """The engine's embedded Dart version string, which names its target."""
+    return (
+        f'{version} (stable) (Mon Jan 1 00:00:00 2026 +0000) on "macos_{arch}"'.encode()
+    )
+
+
+@unittest.skipIf(MachO is None, f"extract_dart_info not importable: {IMPORT_ERROR}")
+class VersionStringSliceTests(unittest.TestCase):
+    """Reading the target out of a universal engine binary.
+
+    Every slice of a universal build carries its own version string. Searching
+    the whole file finds whichever slice comes first, which is how a universal
+    macOS engine reported `x64` while the snapshot it shipped alongside said
+    `arm64` — the analysis would then have been attempted with the wrong Dart
+    VM entirely.
+    """
+
+    def build_universal_engine(self, tmp: str, first: str, second: str) -> str:
+        from fat_macho import build_fat as _build_fat
+
+        cpu = {"x64": CPU_TYPE_X86_64, "arm64": CPU_TYPE_ARM64}
+        fat = _build_fat(
+            [
+                (cpu[first], thin_macho64(cpu[first], version_string(first))),
+                (cpu[second], thin_macho64(cpu[second], version_string(second))),
+            ]
+        )
+        return write(tmp, "FlutterMacOS", fat)
+
+    def test_arch_comes_from_the_selected_slice_not_the_first_one(self):
+        from extract_dart_info import extract_flutter_framework_info
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.build_universal_engine(tmp, first="x64", second="arm64")
+            _, version, arch, os_name = extract_flutter_framework_info(path)
+            self.assertEqual((version, arch, os_name), ("3.11.5", "arm64", "macos"))
+
+    def test_arch_is_right_when_arm64_is_listed_first_too(self):
+        from extract_dart_info import extract_flutter_framework_info
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.build_universal_engine(tmp, first="arm64", second="x64")
+            _, version, arch, os_name = extract_flutter_framework_info(path)
+            self.assertEqual(arch, "arm64")
+
+    def test_thin_engine_still_reports_its_own_arch(self):
+        from extract_dart_info import extract_flutter_framework_info
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(
+                tmp, "FlutterMacOS", thin_macho64(CPU_TYPE_ARM64, version_string("arm64"))
+            )
+            _, _, arch, os_name = extract_flutter_framework_info(path)
+            self.assertEqual((arch, os_name), ("arm64", "macos"))
+
+
 BLUTTER_BIN = os.environ.get("BLUTTER_BIN")
 THIN_SAMPLE = os.environ.get("BLUTTER_TEST_MACHO")
 

--- a/tests/test_find_lib_files.py
+++ b/tests/test_find_lib_files.py
@@ -21,11 +21,17 @@ import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
+# A runner asks for strict mode so a failed dependency install fails the run
+# instead of quietly skipping. Sample-driven skips stay skips.
+STRICT = os.environ.get("BLUTTER_TESTS_STRICT") == "1"
+
 try:
     from blutter import find_lib_files
 
     IMPORT_ERROR = None
 except ImportError as exc:  # pragma: no cover - depends on the environment
+    if STRICT:
+        raise
     find_lib_files = None
     IMPORT_ERROR = str(exc)
 

--- a/tests/test_find_lib_files.py
+++ b/tests/test_find_lib_files.py
@@ -1,0 +1,133 @@
+"""Locating the app and engine binaries in each platform's layout.
+
+Issue #10: a macOS Flutter app ships `FlutterMacOS.framework`, not
+`Flutter.framework`, and uses a versioned bundle — `Versions/A/<name>` with a
+symlink at the top — where iOS uses a flat one. `find_lib_files()` knew only
+the Android and iOS shapes, so a macOS app failed at the first step with
+"Cannot find libflutter file".
+
+Layouts are built from empty files: this is about pathfinding, so the contents
+are irrelevant and no sample binary is needed.
+
+Imports blutter.py, which pulls in requests and pyelftools; run with the
+interpreter Blutter itself uses.
+"""
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+try:
+    from blutter import find_lib_files
+
+    IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover - depends on the environment
+    find_lib_files = None
+    IMPORT_ERROR = str(exc)
+
+
+def make(root: pathlib.Path, *relative_paths: str) -> None:
+    """Create empty files, and the directories leading to them."""
+    for rel in relative_paths:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"")
+
+
+@unittest.skipIf(find_lib_files is None, f"blutter not importable: {IMPORT_ERROR}")
+class FindLibFilesTests(unittest.TestCase):
+    def assertFound(self, root: pathlib.Path, app_rel: str, flutter_rel: str):
+        app, flutter = find_lib_files(str(root))
+        self.assertEqual(pathlib.Path(app), (root / app_rel).resolve())
+        self.assertEqual(pathlib.Path(flutter), (root / flutter_rel).resolve())
+
+    def test_android_extracted_libs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            make(root, "libapp.so", "libflutter.so")
+            self.assertFound(root, "libapp.so", "libflutter.so")
+
+    def test_ios_flat_frameworks(self):
+        """What an iOS .app/Frameworks directory looks like."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            make(root, "App.framework/App", "Flutter.framework/Flutter")
+            self.assertFound(root, "App.framework/App", "Flutter.framework/Flutter")
+
+    def test_macos_versioned_frameworks(self):
+        """What a macOS .app/Contents/Frameworks directory looks like.
+
+        Different engine framework name, and a versioned bundle layout.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            make(
+                root,
+                "App.framework/Versions/A/App",
+                "FlutterMacOS.framework/Versions/A/FlutterMacOS",
+            )
+            self.assertFound(
+                root,
+                "App.framework/Versions/A/App",
+                "FlutterMacOS.framework/Versions/A/FlutterMacOS",
+            )
+
+    def test_macos_bundle_with_the_usual_top_level_symlinks(self):
+        """A real bundle also has App.framework/App -> Versions/A/App.
+
+        Either resolves to the same file, so either is acceptable; what must not
+        happen is failing to find it.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            make(
+                root,
+                "App.framework/Versions/A/App",
+                "FlutterMacOS.framework/Versions/A/FlutterMacOS",
+            )
+            os.symlink("Versions/A/App", root / "App.framework" / "App")
+            os.symlink(
+                "Versions/A/FlutterMacOS",
+                root / "FlutterMacOS.framework" / "FlutterMacOS",
+            )
+            app, flutter = find_lib_files(str(root))
+            self.assertEqual(
+                pathlib.Path(app).resolve(),
+                (root / "App.framework/Versions/A/App").resolve(),
+            )
+            self.assertEqual(
+                pathlib.Path(flutter).resolve(),
+                (root / "FlutterMacOS.framework/Versions/A/FlutterMacOS").resolve(),
+            )
+
+    def test_missing_engine_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            make(root, "App.framework/Versions/A/App")
+            with self.assertRaises(SystemExit) as caught:
+                find_lib_files(str(root))
+            self.assertIn("libflutter", str(caught.exception))
+
+    def test_missing_app_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            make(root, "FlutterMacOS.framework/Versions/A/FlutterMacOS")
+            with self.assertRaises(SystemExit) as caught:
+                find_lib_files(str(root))
+            self.assertIn("libapp", str(caught.exception))
+
+    def test_a_directory_named_like_the_binary_is_not_mistaken_for_it(self):
+        """`App.framework/App` is a directory in some layouts; skip past it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / "App").mkdir()
+            make(root, "App.framework/Versions/A/App", "Flutter.framework/Flutter")
+            self.assertFound(root, "App.framework/Versions/A/App", "Flutter.framework/Flutter")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Blutter reads Android `libapp.so`. This teaches it to read the Mach-O images an
iOS or macOS Flutter application ships — `App.framework/App` alongside
`Flutter.framework/Flutter` or `FlutterMacOS.framework/…/FlutterMacOS`.

Validated on two real applications:

| | iOS | macOS |
| --- | --- | --- |
| sample | a shipped iOS app, Dart 3.10.7, arm64 | AppFlowy 0.13.1 universal, Dart 3.11.5, arm64 |
| disassembly files | 424 | 4482 |
| analysis errors | **0** | **2** |

The two macOS errors are pre-existing arm64 matcher gaps (a `cbnz` fallthrough
where a branch is expected, and two thread-offset loads before a `blr`) with
nothing platform-specific about them.

## The loader

`MachOHelper` locates the four snapshot symbols in `LC_SYMTAB` and lays the
segments out **at their virtual addresses** rather than mapping the file flat.
That detail is load-bearing: `App`'s `__DATA` is zero-fill and its vmaddr range
overlaps `__LINKEDIT` under a flat mapping, and the VM writes into that BSS
while loading the snapshot.

Mach-O structures are declared locally rather than taken from
`<platform/mach_o.h>`, which only exists in recent SDKs. `DartApp` dispatches on
the file magic. Universal binaries are supported, preferring the arm64 slice; a
64-bit fat header is rejected with a clear message rather than misparsed, since
its slice entries are 32 bytes rather than 20.

## The analyzer

iOS and macOS do not use compressed pointers, and the arm64 analyzer assumed
throughout that they were in use. Every crash and all 903 initial analysis
errors on the iOS sample traced back to that one assumption.

The matchers now handle both representations: `isSmiScaledOperand()` for the
sxtw-vs-lsl scaling of a Smi index, `isSmiUntagToNative()` for the sbfx-vs-asr
untag, the static field offset divided by `kWordSize / kCompressedWordSize`
rather than shifted by one, and the args-descriptor element read at
`Array::data_offset()` rather than a hardcoded two pointers. `CSREG_DART_HEAP`
loses a `DART_COMPRESSED_POINTERS` guard it could never have honoured, since
`CodeAnalyzer_arm64.cpp` refers to the register unconditionally. `DartClass`
stops reading a class id out of the null pointer for `Object`, which has no
super class — uncompressed, that garbage reads back negative and the old
`superCid > 0` guard never fired.

**These changes touch code shared with the Android path**, so they were
validated against a compressed build: the same Android `libapp.so` through the
pre-change and post-change binaries produces **byte-identical output** — all
1800 asm files, `objs.txt`, `pp.txt` and the IDA scripts — with 0 analysis
errors on both sides.

One caution for anyone repeating that: a raw diff shows 257 of 1800 files
differing, and it is noise. Blutter prints host addresses of its own process
into its output, in hex and in decimal, so running the *same* binary twice
reproduces the same 257-file diff. Run that control first.

## Build and detection

`scripts/CMakeLists.txt` defines what a real Dart build of each target defines —
android `DART_TARGET_OS_ANDROID`, ios `DART_TARGET_OS_MACOS` **and**
`DART_TARGET_OS_MACOS_IOS`, macos `DART_TARGET_OS_MACOS` alone. Defining only
the `_IOS` sub-flag does not compile, because `Dart::VersionString()` tests the
parent flag first; defining it for a desktop target takes iOS code paths.

`extract_dart_info.py` parses Mach-O, so the Dart version and target are
detected without `--dart-version`. The target is read from the image — the
header names the architecture, `LC_BUILD_VERSION` names the platform — rather
than from the embedded version string, because a universal binary carries **one
string per slice** and beta/dev engines may carry none at all. When the version
string is absent, the engine ids are looked up against the Flutter SDK archive,
matching what the ELF path already did. A macOS engine embeds those ids; an iOS
engine does not, so that case now fails with an actionable message naming
`--dart-version` instead of an assertion.

## Tests

A `tests/` directory, standard library only, no test framework introduced: 48
tests run with `python -m unittest discover -s tests`. Roughly half need nothing
but `requests` and `pyelftools`; the rest opt in to a built binary or a sample
application via environment variables and skip cleanly without them.
`BLUTTER_TESTS_STRICT=1` turns a missing dependency into a failure rather than a
skip, so a runner cannot report success over a suite that did not execute.

Universal-binary fixtures are synthesized rather than committed — a real one is
hundreds of megabytes of third-party software — but the loader test wraps a
**real** thin `App` in a fat container with a stub slice placed first and
requires the analysis to match the thin run line for line, so the synthetic
container is checked against genuine Mach-O content.

## Known follow-ups, not addressed here

- Fixed-offset String element accesses take their index from the TypedData
  payload base, giving a wrong (negative) index on a small number of accesses.
  A String byte read and a TypedData byte read are indistinguishable from the
  displacement alone, so this needs a String entry in `ArrayOp::ArrayType`
  rather than another constant.
- The two arm64 matcher gaps above.

---

Opened as a draft to keep it tracked, not to ask for review yet.

Independent of #214 and #215 — this branch sits directly on `main` and applies
without either of them, so all three can be taken in any order, or separately.
